### PR TITLE
improve fetching and config handling

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -16,19 +16,16 @@ var awsCmd = &cobra.Command{
 	Use:   "aws",
 	Short: "Get AWS IP ranges.",
 	Long:  `Get AWS IPv4 and IPv6 ranges with optional filtering.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
 
 		ipv4 := viper.GetBool("aws_ipv4")
 		ipv6 := viper.GetBool("aws_ipv6")
-		both := !ipv4 && !ipv6
-		var ipVersion []string
-		if ipv4 || both {
-			ipVersion = append(ipVersion, "ipv4")
-		}
-		if ipv6 || both {
-			ipVersion = append(ipVersion, "ipv6")
-		}
+		ipType := resolveIPType(ipv4, ipv6)
 
 		filter := viper.GetString("aws-filter")
 		filterRegion := viper.GetString("aws-filter-region")
@@ -61,17 +58,9 @@ var awsCmd = &cobra.Command{
 			})
 		}
 
-		for _, version := range ipVersion {
-			if err := aws.GetIPRanges(cmd.Context(), aws.Config{
-				Source:    source,
-				IPType:    version,
-				Filter:    awsFilter,
-				Verbosity: verbosity,
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
+		return aws.GetIPRanges(cmd.Context(), aws.Config{
+			Source: source, IPType: ipType, Filter: awsFilter, Verbosity: verbosity,
+		})
 	},
 }
 

--- a/cmd/azure.go
+++ b/cmd/azure.go
@@ -16,19 +16,16 @@ var azureCmd = &cobra.Command{
 	Use:   "azure",
 	Short: "Get Azure IP ranges.",
 	Long:  `Get Azure IPv4 and IPv6 ranges from the Public cloud service tags, with optional filtering.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
 
 		ipv4 := viper.GetBool("azure_ipv4")
 		ipv6 := viper.GetBool("azure_ipv6")
-		both := !ipv4 && !ipv6
-		var ipVersions []string
-		if ipv4 || both {
-			ipVersions = append(ipVersions, "ipv4")
-		}
-		if ipv6 || both {
-			ipVersions = append(ipVersions, "ipv6")
-		}
+		ipType := resolveIPType(ipv4, ipv6)
 
 		filter := viper.GetString("azure-filter")
 		filterRegion := viper.GetString("azure-filter-region")
@@ -60,17 +57,9 @@ var azureCmd = &cobra.Command{
 			})
 		}
 
-		for _, version := range ipVersions {
-			if err := azure.GetIPRanges(cmd.Context(), azure.Config{
-				Source:    source,
-				IPType:    version,
-				Filter:    azureFilter,
-				Verbosity: verbosity,
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
+		return azure.GetIPRanges(cmd.Context(), azure.Config{
+			Source: source, IPType: ipType, Filter: azureFilter, Verbosity: verbosity,
+		})
 	},
 }
 

--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -11,11 +11,20 @@ var cloudflareCmd = &cobra.Command{
 	Use:   "cloudflare",
 	Short: "Get Cloudflare IP ranges",
 	Long:  `Retrieve Cloudflare IPv4 and IPv6 ranges with optional verbosity levels.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
 
 		ipv4 := viper.GetBool("cloudflare_ipv4")
 		ipv6 := viper.GetBool("cloudflare_ipv6")
+		if viper.GetString("source") != "hosted" {
+			return cloudflare.GetIPRanges(cmd.Context(), cloudflare.Config{
+				Source: utils.ResolveSource("cloudflare"), Verbosity: verbosity,
+			})
+		}
 		both := !ipv4 && !ipv6
 		var ipVersions []string
 		if ipv4 || both {

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -15,19 +15,16 @@ var doCmd = &cobra.Command{
 	Use:   "do",
 	Short: "Get Digital Ocean IP ranges",
 	Long:  `Retrieve Digital Ocean IPv4 and IPv6 ranges with optional verbosity levels.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
 
 		ipv4 := viper.GetBool("do_ipv4")
 		ipv6 := viper.GetBool("do_ipv6")
-		both := !ipv4 && !ipv6
-		var ipVersions []string
-		if ipv4 || both {
-			ipVersions = append(ipVersions, "ipv4")
-		}
-		if ipv6 || both {
-			ipVersions = append(ipVersions, "ipv6")
-		}
+		ipType := resolveIPType(ipv4, ipv6)
 
 		source := utils.ResolveSource("digitalocean")
 		filters := digitalocean.Filters{
@@ -50,17 +47,9 @@ var doCmd = &cobra.Command{
 			})
 		}
 
-		for _, version := range ipVersions {
-			if err := digitalocean.GetIPRanges(cmd.Context(), digitalocean.Config{
-				Source:    source,
-				IPType:    version,
-				Filters:   filters,
-				Verbosity: verbosity,
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
+		return digitalocean.GetIPRanges(cmd.Context(), digitalocean.Config{
+			Source: source, IPType: ipType, Filters: filters, Verbosity: verbosity,
+		})
 	},
 }
 

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -15,8 +15,12 @@ var githubCmd = &cobra.Command{
 	Use:   "github",
 	Short: "Get GitHub IP ranges.",
 	Long:  `Get GitHub IPv4 and IPv6 ranges with optional service filtering.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
 
 		ipv4 := viper.GetBool("github_ipv4")
 		ipv6 := viper.GetBool("github_ipv6")

--- a/cmd/icloud.go
+++ b/cmd/icloud.go
@@ -15,17 +15,14 @@ var icloudCmd = &cobra.Command{
 	Use:   "icloud",
 	Short: "Get iCloud private relay IP ranges.",
 	Long:  `Get iCloud private relay IPv4 and IPv6 ranges.`,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbosity := resolveVerbosity(cmd)
-
-		ipType := "ipv4"
-		if viper.GetBool("icloud_ipv6") {
-			ipType = "ipv6"
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
 		}
 
-		if !viper.GetBool("icloud_ipv4") && !viper.GetBool("icloud_ipv6") {
-			ipType = "both"
-		}
+		ipType := resolveIPType(viper.GetBool("icloud_ipv4"), viper.GetBool("icloud_ipv6"))
 
 		filters := icloud.Filters{
 			Country: viper.GetStringSlice("icloud-filter-country"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/kaumnen/cipr/internal/utils"
 	"github.com/spf13/cobra"
@@ -17,9 +18,13 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "cipr",
-	Version: version,
-	Short:   "Retrieve IP ranges from cloud providers and services",
+	Use:          "cipr",
+	Version:      version,
+	Short:        "Retrieve IP ranges from cloud providers and services",
+	SilenceUsage: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return initConfig()
+	},
 	Long: `cipr is a CLI tool for retrieving IP ranges from various cloud providers
 and services (AWS, Azure, Cloudflare, DigitalOcean, GitHub, iCloud Private Relay).
 
@@ -36,8 +41,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
 	if version != "" {
 		utils.UserAgent = "cipr/" + version
 	}
@@ -53,9 +56,10 @@ func init() {
 	viper.BindPFlag("verbose_mode", rootCmd.PersistentFlags().Lookup("verbose-mode"))
 	viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
 	viper.BindPFlag("no_cache", rootCmd.PersistentFlags().Lookup("no-cache"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 }
 
-func initConfig() {
+func initConfig() error {
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
@@ -67,33 +71,49 @@ func initConfig() {
 		viper.SetConfigType("toml")
 
 		if _, err := os.Stat(configPath); os.IsNotExist(err) {
-			createDefaultConfig(configPath)
+			if err := createDefaultConfig(configPath); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return fmt.Errorf("inspect config file: %w", err)
 		}
 	}
 
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error reading config file:", err)
+		return fmt.Errorf("read config file: %w", err)
 	}
+	return nil
 }
 
-func resolveVerbosity(cmd *cobra.Command) string {
+func resolveVerbosity(cmd *cobra.Command) (string, error) {
 	var verbosity string
 	switch {
 	case cmd.Flags().Changed("verbose-mode"):
-		verbosity = viper.GetString("verbose_mode")
-	case viper.GetBool("verbose"):
-		verbosity = "full"
+		verbosity, _ = cmd.Flags().GetString("verbose-mode")
+	case cmd.Flags().Changed("verbose"):
+		enabled, _ := cmd.Flags().GetBool("verbose")
+		if enabled {
+			verbosity = "full"
+		} else {
+			verbosity = "none"
+		}
 	default:
-		verbosity = "none"
+		verbosity = viper.GetString("verbose_mode")
+		if verbosity == "" || verbosity == "none" && viper.GetBool("verbose") {
+			if viper.GetBool("verbose") {
+				verbosity = "full"
+			} else {
+				verbosity = "none"
+			}
+		}
 	}
 
 	if !isValidVerbosity(verbosity) {
-		fmt.Fprintf(os.Stderr, "Invalid verbosity level: %s. Allowed values are: none, mini, full.\n", verbosity)
-		os.Exit(1)
+		return "", fmt.Errorf("invalid verbosity level %q (allowed: none, mini, full)", verbosity)
 	}
-	return verbosity
+	return verbosity, nil
 }
 
 func isValidVerbosity(v string) bool {
@@ -104,21 +124,19 @@ func isValidVerbosity(v string) bool {
 	return false
 }
 
-func createDefaultConfig(configPath string) {
+func createDefaultConfig(configPath string) error {
 	dir := filepath.Dir(configPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			fmt.Fprintln(os.Stderr, "Error creating config directory:", err)
-			os.Exit(1)
+			return fmt.Errorf("create config directory: %w", err)
 		}
 	}
 
-	file, err := os.Create(configPath)
+	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating config file:", err)
-		os.Exit(1)
+		return fmt.Errorf("create config file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	const header = `# cipr config. Override per-provider data sources here, or pass --source on
 # the command line. For each provider:
@@ -130,8 +148,7 @@ func createDefaultConfig(configPath string) {
 
 `
 	if _, err := fmt.Fprint(file, header); err != nil {
-		fmt.Fprintln(os.Stderr, "Error writing config file:", err)
-		os.Exit(1)
+		return fmt.Errorf("write config file: %w", err)
 	}
 
 	keys := make([]string, 0, len(utils.DefaultEndpoints))
@@ -143,8 +160,19 @@ func createDefaultConfig(configPath string) {
 	for _, k := range keys {
 		_, err := fmt.Fprintf(file, "%s_endpoint = %q\n%s_local_file = \"\"\n%s_cache_ttl = \"24h\"\n\n", k, utils.DefaultEndpoints[k], k, k)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error writing config file:", err)
-			os.Exit(1)
+			return fmt.Errorf("write config file: %w", err)
 		}
+	}
+	return file.Close()
+}
+
+func resolveIPType(ipv4, ipv6 bool) string {
+	switch {
+	case ipv4 && !ipv6:
+		return "ipv4"
+	case ipv6 && !ipv4:
+		return "ipv6"
+	default:
+		return "both"
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveIPType(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipv4, ipv6 bool
+		want       string
+	}{
+		{name: "neither", want: "both"},
+		{name: "ipv4", ipv4: true, want: "ipv4"},
+		{name: "ipv6", ipv6: true, want: "ipv6"},
+		{name: "both", ipv4: true, ipv6: true, want: "both"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveIPType(tt.ipv4, tt.ipv6))
+		})
+	}
+}
+
+func TestResolveVerbosityFromConfig(t *testing.T) {
+	old := viper.Get("verbose_mode")
+	viper.Set("verbose_mode", "mini")
+	t.Cleanup(func() { viper.Set("verbose_mode", old) })
+
+	got, err := resolveVerbosity(&cobra.Command{})
+	require.NoError(t, err)
+	assert.Equal(t, "mini", got)
+}
+
+func TestResolveVerbosityRejectsInvalidValue(t *testing.T) {
+	old := viper.Get("verbose_mode")
+	viper.Set("verbose_mode", "loud")
+	t.Cleanup(func() { viper.Set("verbose_mode", old) })
+
+	_, err := resolveVerbosity(&cobra.Command{})
+	require.Error(t, err)
+}

--- a/internal/aws/logic.go
+++ b/internal/aws/logic.go
@@ -133,12 +133,12 @@ func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]IPPrefix,
 	}
 
 	var prefixes []IPPrefix
-	if ipType == "ipv4" || ipType == "" {
+	if ipType == "ipv4" || ipType == "both" || ipType == "" {
 		for _, prefix := range data.Prefixes {
 			prefixes = append(prefixes, prefix)
 		}
 	}
-	if ipType == "ipv6" || ipType == "" {
+	if ipType == "ipv6" || ipType == "both" || ipType == "" {
 		for _, prefix := range data.IPv6Prefixes {
 			prefixes = append(prefixes, prefix)
 		}

--- a/internal/azure/logic.go
+++ b/internal/azure/logic.go
@@ -57,6 +57,7 @@ var jsonURLRegex = regexp.MustCompile(`https://download\.microsoft\.com/[^"' ]+S
 // download page is almost certainly the lightweight anti-bot stub
 // rather than the full ~120 KB rendered page.
 const antiBotStubThreshold = 10 * 1024
+const maxAzurePageBytes = 4 << 20
 
 const recoveryHint = "Workarounds: download the JSON from the page in a browser " +
 	"and pass `--source <path>`, or set `azure_local_file` in cipr.toml. " +
@@ -127,9 +128,7 @@ func fetchRawData(ctx context.Context, source string) (string, error) {
 	switch {
 	case strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://"):
 		endpointURL = source
-	case strings.Contains(source, "/"):
-		return utils.GetRawData(ctx, source)
-	default:
+	case source == "azure" || viper.IsSet(source+"_endpoint") || viper.IsSet(source+"_local_file"):
 		if lf := viper.GetString(source + "_local_file"); lf != "" {
 			return utils.GetRawData(ctx, source)
 		}
@@ -138,6 +137,8 @@ func fetchRawData(ctx context.Context, source string) (string, error) {
 			endpointURL = utils.DefaultEndpoints[source]
 		}
 		cacheKey = source
+	default:
+		return utils.GetRawData(ctx, source)
 	}
 
 	if endpointURL == "" {
@@ -176,9 +177,12 @@ func scrapeJSONURL(ctx context.Context, pageURL string) (string, error) {
 		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, pageURL)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAzurePageBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("read body from %s: %w", pageURL, err)
+	}
+	if len(body) > maxAzurePageBytes {
+		return "", fmt.Errorf("page from %s exceeds %d byte limit", pageURL, maxAzurePageBytes)
 	}
 
 	match := jsonURLRegex.FindString(string(body))

--- a/internal/digitalocean/logic.go
+++ b/internal/digitalocean/logic.go
@@ -1,9 +1,12 @@
 package digitalocean
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/kaumnen/cipr/internal/utils"
@@ -83,13 +86,15 @@ func parseRecords(rawData string) ([]IPRange, error) {
 	r := csv.NewReader(strings.NewReader(rawData))
 	r.FieldsPerRecord = -1
 
-	records, err := r.ReadAll()
-	if err != nil {
-		return nil, fmt.Errorf("parse digitalocean csv: %w", err)
-	}
-
 	var ipRanges []IPRange
-	for _, record := range records {
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse digitalocean csv: %w", err)
+		}
 		ipRange := IPRange{}
 		if len(record) > 0 {
 			ipRange.IPRange = strings.TrimSpace(record[0])
@@ -146,26 +151,28 @@ func printIPRanges(ipRanges []IPRange, verbosity string) {
 		return
 	}
 
+	w := bufio.NewWriter(os.Stdout)
+	defer func() { _ = w.Flush() }()
 	var printFunc func(IPRange)
 
 	switch verbosity {
 	case "none":
 		printFunc = func(ip IPRange) {
-			fmt.Println(ip.IPRange)
+			_, _ = fmt.Fprintln(w, ip.IPRange)
 		}
 	case "mini":
 		printFunc = func(ip IPRange) {
-			fmt.Printf("%s,%s,%s,%s,%s\n",
+			_, _ = fmt.Fprintf(w, "%s,%s,%s,%s,%s\n",
 				ip.IPRange, ip.Country, ip.Region, ip.City, ip.Zip)
 		}
 	case "full":
 		printFunc = func(ip IPRange) {
-			fmt.Printf("IP Range: %s, Country: %s, Region: %s, City: %s, ZIP: %s\n",
+			_, _ = fmt.Fprintf(w, "IP Range: %s, Country: %s, Region: %s, City: %s, ZIP: %s\n",
 				ip.IPRange, ip.Country, ip.Region, ip.City, ip.Zip)
 		}
 	default:
 		printFunc = func(ip IPRange) {
-			fmt.Println(ip.IPRange)
+			_, _ = fmt.Fprintln(w, ip.IPRange)
 		}
 	}
 

--- a/internal/icloud/logic.go
+++ b/internal/icloud/logic.go
@@ -1,9 +1,12 @@
 package icloud
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/kaumnen/cipr/internal/utils"
@@ -79,13 +82,15 @@ func parseRecords(rawData string) ([]IPRange, error) {
 	r := csv.NewReader(strings.NewReader(rawData))
 	r.FieldsPerRecord = -1
 
-	records, err := r.ReadAll()
-	if err != nil {
-		return nil, fmt.Errorf("parse icloud csv: %w", err)
-	}
-
 	var ipRanges []IPRange
-	for _, record := range records {
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse icloud csv: %w", err)
+		}
 		ipRange := IPRange{}
 		if len(record) > 0 {
 			ipRange.IPRange = strings.TrimSpace(record[0])
@@ -138,26 +143,28 @@ func printIPRanges(ipRanges []IPRange, verbosity string) {
 		return
 	}
 
+	w := bufio.NewWriter(os.Stdout)
+	defer func() { _ = w.Flush() }()
 	var printFunc func(IPRange)
 
 	switch verbosity {
 	case "none":
 		printFunc = func(ip IPRange) {
-			fmt.Println(ip.IPRange)
+			_, _ = fmt.Fprintln(w, ip.IPRange)
 		}
 	case "mini":
 		printFunc = func(ip IPRange) {
-			fmt.Printf("%s,%s,%s,%s\n",
+			_, _ = fmt.Fprintf(w, "%s,%s,%s,%s\n",
 				ip.IPRange, ip.Country, ip.Region, ip.City)
 		}
 	case "full":
 		printFunc = func(ip IPRange) {
-			fmt.Printf("IP Range: %s, Country: %s, Region: %s, City: %s\n",
+			_, _ = fmt.Fprintf(w, "IP Range: %s, Country: %s, Region: %s, City: %s\n",
 				ip.IPRange, ip.Country, ip.Region, ip.City)
 		}
 	default:
 		printFunc = func(ip IPRange) {
-			fmt.Println(ip.IPRange)
+			_, _ = fmt.Fprintln(w, ip.IPRange)
 		}
 	}
 

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -102,15 +102,25 @@ func writeCache(key string, data []byte) error {
 		return err
 	}
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create cache temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(data); err != nil {
 		return fmt.Errorf("write cache: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close cache: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("finalize cache: %w", err)
 	}
 	return nil

--- a/internal/utils/raw_data_handler.go
+++ b/internal/utils/raw_data_handler.go
@@ -19,19 +19,18 @@ var UserAgent = "cipr"
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 const defaultCacheTTL = 24 * time.Hour
+const maxResponseBytes = 64 << 20
 
 // GetRawData fetches IP-range data for the given source. The source may be
 // a config-key prefix (e.g. "aws", looked up in viper), an http(s) URL, or
-// a filesystem path containing a slash.
+// a filesystem path.
 func GetRawData(ctx context.Context, source string) (string, error) {
 	var endpointURL, localFile, cacheKey string
 
 	switch {
 	case strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://"):
 		endpointURL = source
-	case strings.Contains(source, "/"):
-		localFile = source
-	default:
+	case isHostedKey(source):
 		endpointURL = viper.GetString(source + "_endpoint")
 		localFile = viper.GetString(source + "_local_file")
 		if endpointURL == "" && localFile == "" {
@@ -40,6 +39,8 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 		if localFile == "" {
 			cacheKey = source
 		}
+	default:
+		localFile = source
 	}
 
 	if localFile != "" {
@@ -78,13 +79,31 @@ func loadFromEndpoint(ctx context.Context, url string) (string, error) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode >= 400 {
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("unexpected status %d from %s", response.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := readAllLimited(response.Body, maxResponseBytes)
 	if err != nil {
 		return "", fmt.Errorf("read body from %s: %w", url, err)
 	}
 	return string(body), nil
+}
+
+func isHostedKey(source string) bool {
+	if _, ok := DefaultEndpoints[source]; ok {
+		return true
+	}
+	return viper.IsSet(source+"_endpoint") || viper.IsSet(source+"_local_file")
+}
+
+func readAllLimited(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response exceeds %d byte limit", limit)
+	}
+	return body, nil
 }

--- a/internal/utils/raw_data_handler_test.go
+++ b/internal/utils/raw_data_handler_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadFromFile(t *testing.T) {
@@ -28,6 +30,25 @@ func TestLoadFromFile(t *testing.T) {
 func TestLoadFromFile_Missing(t *testing.T) {
 	_, err := loadFromFile(filepath.Join(t.TempDir(), "does-not-exist"))
 	assert.Error(t, err)
+}
+
+func TestGetRawData_BareRelativePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile("ranges.csv", []byte("local"), 0o600))
+
+	got, err := GetRawData(context.Background(), "ranges.csv")
+	require.NoError(t, err)
+	assert.Equal(t, "local", got)
+}
+
+func TestReadAllLimited(t *testing.T) {
+	got, err := readAllLimited(bytes.NewBufferString("1234"), 4)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("1234"), got)
+
+	_, err = readAllLimited(bytes.NewBufferString("12345"), 4)
+	require.Error(t, err)
 }
 
 func TestLoadFromEndpoint_OK(t *testing.T) {


### PR DESCRIPTION
## Summary
- fetch and parse dual-stack provider data once
- fix IP-family, custom-source, verbosity, and config handling edge cases
- reduce CSV memory use, buffer large output, and harden HTTP/cache handling
- add command and raw-data regression tests

## Validation
- go test -race -cover ./...
- go build ./...
- go vet ./...
- go mod tidy -diff
- golangci-lint run