### PR TITLE
fix: resolve quick-win issues

### DIFF
--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build app
         run: go build -v ./...
 
+      - name: Run smoke tests
+        run: ./scripts/smoke-test.sh
+
       - name: Run Tests
         run: go test -v -coverprofile=coverage.out ./...
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output (equivalent to --verbose-mode=full)")
 	rootCmd.PersistentFlags().String("verbose-mode", "none", "Verbosity level: none, mini, full. Overrides --verbose")
-	rootCmd.PersistentFlags().String("source", "hosted", "Custom data source for ip ranges (url or path). Must have https:// for urls.")
+	rootCmd.PersistentFlags().String("source", "config", "Data source: config, an HTTP(S) URL, or a local file path")
 	rootCmd.PersistentFlags().Bool("no-cache", false, "Bypass cache (skip read and write)")
 
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
@@ -140,7 +140,7 @@ func createDefaultConfig(configPath string) error {
 
 	const header = `# cipr config. Override per-provider data sources here, or pass --source on
 # the command line. For each provider:
-#   <provider>_endpoint   = URL fetched when --source=hosted (the default)
+#   <provider>_endpoint   = URL fetched when --source=config (the default)
 #   <provider>_local_file = if set, read ranges from this path instead of the network
 #   <provider>_cache_ttl  = how long to reuse a cached hosted response. Go duration
 #                           string ("24h", "30m"). "0s" disables caching for this

--- a/internal/aws/logic.go
+++ b/internal/aws/logic.go
@@ -131,6 +131,19 @@ func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]IPPrefix,
 	if err := json.Unmarshal([]byte(rawData), &data); err != nil {
 		return nil, fmt.Errorf("parse aws ip-ranges json: %w", err)
 	}
+	if len(data.Prefixes) == 0 && len(data.IPv6Prefixes) == 0 {
+		return nil, fmt.Errorf("validate aws ip-ranges json: no IP ranges found")
+	}
+	for i, prefix := range data.Prefixes {
+		if !utils.IsCIDR(prefix.IPAddress) {
+			return nil, fmt.Errorf("validate aws IPv4 prefix %d: %q is not a valid CIDR", i+1, prefix.IPAddress)
+		}
+	}
+	for i, prefix := range data.IPv6Prefixes {
+		if !utils.IsCIDR(prefix.IPv6Address) {
+			return nil, fmt.Errorf("validate aws IPv6 prefix %d: %q is not a valid CIDR", i+1, prefix.IPv6Address)
+		}
+	}
 
 	var prefixes []IPPrefix
 	if ipType == "ipv4" || ipType == "both" || ipType == "" {

--- a/internal/aws/logic_test.go
+++ b/internal/aws/logic_test.go
@@ -99,6 +99,25 @@ func TestFiltrateIPRanges(t *testing.T) {
 	}
 }
 
+func TestFiltrateIPRanges_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "malformed JSON", raw: `{`, want: "parse aws"},
+		{name: "empty payload", raw: `{}`, want: "no IP ranges found"},
+		{name: "invalid CIDR", raw: `{"prefixes":[{"ip_prefix":"not-a-cidr"}]}`, want: "IPv4 prefix 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := filtrateIPRanges(tt.raw, "ipv4", []string{"*", "*", "*"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
 func TestPrintIPRanges(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/internal/azure/logic.go
+++ b/internal/azure/logic.go
@@ -128,7 +128,7 @@ func fetchRawData(ctx context.Context, source string) (string, error) {
 	switch {
 	case strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://"):
 		endpointURL = source
-	case source == "azure" || viper.IsSet(source+"_endpoint") || viper.IsSet(source+"_local_file"):
+	case utils.IsConfiguredSource(source):
 		if lf := viper.GetString(source + "_local_file"); lf != "" {
 			return utils.GetRawData(ctx, source)
 		}
@@ -143,6 +143,9 @@ func fetchRawData(ctx context.Context, source string) (string, error) {
 
 	if endpointURL == "" {
 		return utils.GetRawData(ctx, source)
+	}
+	if err := utils.ValidateHTTPURL(endpointURL); err != nil {
+		return "", fmt.Errorf("invalid endpoint for source %q: %w", source, err)
 	}
 
 	return utils.GetCached(ctx, cacheKey, func(ctx context.Context) (string, error) {
@@ -217,6 +220,19 @@ func filtrateIPRanges(raw, ipType string, filterSlice []string) ([]Prefix, error
 	var data rawData
 	if err := json.Unmarshal([]byte(raw), &data); err != nil {
 		return nil, fmt.Errorf("parse azure service-tags json: %w", err)
+	}
+
+	totalPrefixes := 0
+	for _, v := range data.Values {
+		for i, addr := range v.Properties.AddressPrefixes {
+			totalPrefixes++
+			if !utils.IsCIDR(addr) {
+				return nil, fmt.Errorf("validate azure service %q prefix %d: %q is not a valid CIDR", v.Name, i+1, addr)
+			}
+		}
+	}
+	if totalPrefixes == 0 {
+		return nil, fmt.Errorf("validate azure service-tags json: no IP ranges found")
 	}
 
 	var result []Prefix

--- a/internal/azure/logic_test.go
+++ b/internal/azure/logic_test.go
@@ -119,6 +119,19 @@ func TestFiltrateIPRangesInvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFiltrateIPRangesValidation(t *testing.T) {
+	t.Run("empty payload", func(t *testing.T) {
+		_, err := filtrateIPRanges(`{}`, "ipv4", []string{"*", "*"})
+		assert.ErrorContains(t, err, "no IP ranges found")
+	})
+
+	t.Run("invalid CIDR", func(t *testing.T) {
+		raw := `{"values":[{"name":"BadService","properties":{"addressPrefixes":["not-a-cidr"]}}]}`
+		_, err := filtrateIPRanges(raw, "ipv4", []string{"*", "*"})
+		assert.ErrorContains(t, err, `service "BadService" prefix 1`)
+	})
+}
+
 func TestJSONURLRegex(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/cloudflare/logic.go
+++ b/internal/cloudflare/logic.go
@@ -18,20 +18,30 @@ func GetIPRanges(ctx context.Context, config Config) error {
 	if err != nil {
 		return err
 	}
-	printIPRanges(parseIPRanges(rawData), config.Verbosity)
+	ipRanges, err := parseIPRanges(rawData)
+	if err != nil {
+		return err
+	}
+	printIPRanges(ipRanges, config.Verbosity)
 	return nil
 }
 
-func parseIPRanges(rawData string) []string {
+func parseIPRanges(rawData string) ([]string, error) {
 	lines := strings.Split(rawData, "\n")
 	var ipRanges []string
-	for _, line := range lines {
+	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" {
+			if !utils.IsCIDR(trimmed) {
+				return nil, fmt.Errorf("validate cloudflare line %d: %q is not a valid CIDR", i+1, trimmed)
+			}
 			ipRanges = append(ipRanges, trimmed)
 		}
 	}
-	return ipRanges
+	if len(ipRanges) == 0 {
+		return nil, fmt.Errorf("validate cloudflare data: no IP ranges found")
+	}
+	return ipRanges, nil
 }
 
 func printIPRanges(ipRanges []string, verbosity string) {

--- a/internal/cloudflare/logic_test.go
+++ b/internal/cloudflare/logic_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadFixture(t *testing.T, name string) string {
@@ -24,16 +25,17 @@ func TestParseIPRanges(t *testing.T) {
 		name     string
 		input    string
 		expected []string
+		wantErr  bool
 	}{
 		{
-			name:     "Empty input",
-			input:    "",
-			expected: nil,
+			name:    "Empty input",
+			input:   "",
+			wantErr: true,
 		},
 		{
-			name:     "Whitespace-only input",
-			input:    "   \n\t\n  ",
-			expected: nil,
+			name:    "Whitespace-only input",
+			input:   "   \n\t\n  ",
+			wantErr: true,
 		},
 		{
 			name:     "Single line, no trailing newline",
@@ -54,20 +56,33 @@ func TestParseIPRanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := parseIPRanges(tc.input)
+			result, err := parseIPRanges(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 }
 
 func TestParseIPRanges_Fixtures(t *testing.T) {
-	v4 := parseIPRanges(loadFixture(t, "cloudflare_ipv4.txt"))
+	v4, err := parseIPRanges(loadFixture(t, "cloudflare_ipv4.txt"))
+	require.NoError(t, err)
 	assert.Len(t, v4, 15, "cloudflare_ipv4.txt should yield 15 prefixes")
 	assert.Equal(t, "173.245.48.0/20", v4[0])
 
-	v6 := parseIPRanges(loadFixture(t, "cloudflare_ipv6.txt"))
+	v6, err := parseIPRanges(loadFixture(t, "cloudflare_ipv6.txt"))
+	require.NoError(t, err)
 	assert.Len(t, v6, 7, "cloudflare_ipv6.txt should yield 7 prefixes")
 	assert.Equal(t, "2400:cb00::/32", v6[0])
+}
+
+func TestParseIPRanges_InvalidCIDR(t *testing.T) {
+	_, err := parseIPRanges("1.1.1.0/24\nnot-a-cidr\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 2")
 }
 
 func TestPrintIPRanges(t *testing.T) {

--- a/internal/digitalocean/logic.go
+++ b/internal/digitalocean/logic.go
@@ -87,6 +87,7 @@ func parseRecords(rawData string) ([]IPRange, error) {
 	r.FieldsPerRecord = -1
 
 	var ipRanges []IPRange
+	row := 0
 	for {
 		record, err := r.Read()
 		if err == io.EOF {
@@ -95,6 +96,7 @@ func parseRecords(rawData string) ([]IPRange, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse digitalocean csv: %w", err)
 		}
+		row++
 		ipRange := IPRange{}
 		if len(record) > 0 {
 			ipRange.IPRange = strings.TrimSpace(record[0])
@@ -111,7 +113,13 @@ func parseRecords(rawData string) ([]IPRange, error) {
 		if len(record) > 4 {
 			ipRange.Zip = strings.TrimSpace(record[4])
 		}
+		if !utils.IsCIDR(ipRange.IPRange) {
+			return nil, fmt.Errorf("validate digitalocean CSV row %d: %q is not a valid CIDR", row, ipRange.IPRange)
+		}
 		ipRanges = append(ipRanges, ipRange)
+	}
+	if len(ipRanges) == 0 {
+		return nil, fmt.Errorf("validate digitalocean csv: no IP ranges found")
 	}
 	return ipRanges, nil
 }

--- a/internal/digitalocean/logic_test.go
+++ b/internal/digitalocean/logic_test.go
@@ -30,13 +30,12 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 func TestParseRecords(t *testing.T) {
-	t.Run("empty input yields no records", func(t *testing.T) {
-		got, err := parseRecords("")
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+	t.Run("empty input is rejected", func(t *testing.T) {
+		_, err := parseRecords("")
+		assert.ErrorContains(t, err, "no IP ranges found")
 	})
 
-	t.Run("trims whitespace and tolerates partial columns", func(t *testing.T) {
+	t.Run("trims whitespace and tolerates optional metadata columns", func(t *testing.T) {
 		input := "1.1.1.0/24, US , CA , San Francisco , 94107\n2.2.2.0/24,US,CA,Oakland\n3.3.3.0/24,US,CA\n4.4.4.0/24,US\n5.5.5.0/24\n"
 		got, err := parseRecords(input)
 		require.NoError(t, err)
@@ -47,6 +46,11 @@ func TestParseRecords(t *testing.T) {
 			{IPRange: "4.4.4.0/24", Country: "US"},
 			{IPRange: "5.5.5.0/24"},
 		}, got)
+	})
+
+	t.Run("rejects invalid CIDR", func(t *testing.T) {
+		_, err := parseRecords("not-a-cidr,US,CA,San Francisco,94107\n")
+		assert.ErrorContains(t, err, "row 1")
 	})
 
 	t.Run("propagates csv parse errors", func(t *testing.T) {

--- a/internal/github/logic.go
+++ b/internal/github/logic.go
@@ -72,9 +72,15 @@ func parseMeta(rawData string) ([]IPRange, error) {
 		if err := json.Unmarshal(raw[service], &cidrs); err != nil {
 			continue
 		}
-		for _, cidr := range cidrs {
+		for i, cidr := range cidrs {
+			if !utils.IsCIDR(cidr) {
+				return nil, fmt.Errorf("validate github service %q prefix %d: %q is not a valid CIDR", service, i+1, cidr)
+			}
 			ranges = append(ranges, IPRange{CIDR: cidr, Service: service})
 		}
+	}
+	if len(ranges) == 0 {
+		return nil, fmt.Errorf("validate github meta json: no IP ranges found")
 	}
 	return ranges, nil
 }

--- a/internal/github/logic_test.go
+++ b/internal/github/logic_test.go
@@ -65,6 +65,29 @@ func TestParseMeta(t *testing.T) {
 	assert.Len(t, ranges, 32)
 }
 
+func TestParseMeta_Validation(t *testing.T) {
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, err := parseMeta(`{`)
+		assert.ErrorContains(t, err, "parse github meta json")
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		_, err := parseMeta(`{}`)
+		assert.ErrorContains(t, err, "no IP ranges found")
+	})
+
+	t.Run("invalid CIDR", func(t *testing.T) {
+		_, err := parseMeta(`{"web":["1.1.1.0/24","not-a-cidr"]}`)
+		assert.ErrorContains(t, err, `service "web" prefix 2`)
+	})
+
+	t.Run("unknown non-range metadata is ignored", func(t *testing.T) {
+		ranges, err := parseMeta(`{"web":["1.1.1.0/24"],"future_metadata":{"enabled":true}}`)
+		require.NoError(t, err)
+		assert.Equal(t, []IPRange{{CIDR: "1.1.1.0/24", Service: "web"}}, ranges)
+	})
+}
+
 func TestFiltrate(t *testing.T) {
 	raw := mockGetReq()
 	ranges, err := parseMeta(raw)

--- a/internal/icloud/logic.go
+++ b/internal/icloud/logic.go
@@ -83,6 +83,7 @@ func parseRecords(rawData string) ([]IPRange, error) {
 	r.FieldsPerRecord = -1
 
 	var ipRanges []IPRange
+	row := 0
 	for {
 		record, err := r.Read()
 		if err == io.EOF {
@@ -91,6 +92,7 @@ func parseRecords(rawData string) ([]IPRange, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse icloud csv: %w", err)
 		}
+		row++
 		ipRange := IPRange{}
 		if len(record) > 0 {
 			ipRange.IPRange = strings.TrimSpace(record[0])
@@ -104,7 +106,13 @@ func parseRecords(rawData string) ([]IPRange, error) {
 		if len(record) > 3 {
 			ipRange.City = strings.TrimSpace(record[3])
 		}
+		if !utils.IsCIDR(ipRange.IPRange) {
+			return nil, fmt.Errorf("validate icloud CSV row %d: %q is not a valid CIDR", row, ipRange.IPRange)
+		}
 		ipRanges = append(ipRanges, ipRange)
+	}
+	if len(ipRanges) == 0 {
+		return nil, fmt.Errorf("validate icloud csv: no IP ranges found")
 	}
 	return ipRanges, nil
 }

--- a/internal/icloud/logic_test.go
+++ b/internal/icloud/logic_test.go
@@ -30,13 +30,12 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 func TestParseRecords(t *testing.T) {
-	t.Run("empty input yields no records", func(t *testing.T) {
-		got, err := parseRecords("")
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+	t.Run("empty input is rejected", func(t *testing.T) {
+		_, err := parseRecords("")
+		assert.ErrorContains(t, err, "no IP ranges found")
 	})
 
-	t.Run("trims whitespace and tolerates partial columns", func(t *testing.T) {
+	t.Run("trims whitespace and tolerates optional metadata columns", func(t *testing.T) {
 		input := "172.224.224.0/27, GB , GB-EN , London\n2a02:26f7::/64,US,US-NY\n3.3.3.0/24,US\n4.4.4.0/24\n"
 		got, err := parseRecords(input)
 		require.NoError(t, err)
@@ -46,6 +45,11 @@ func TestParseRecords(t *testing.T) {
 			{IPRange: "3.3.3.0/24", Country: "US"},
 			{IPRange: "4.4.4.0/24"},
 		}, got)
+	})
+
+	t.Run("rejects invalid CIDR", func(t *testing.T) {
+		_, err := parseRecords("not-a-cidr,GB,GB-EN,London\n")
+		assert.ErrorContains(t, err, "row 1")
 	})
 
 	t.Run("propagates csv parse errors", func(t *testing.T) {

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -20,15 +20,25 @@ var DefaultEndpoints = map[string]string{
 	"github":          "https://api.github.com/meta",
 }
 
-// ResolveSource returns the source token to pass to GetRawData. When the
-// global --source is "hosted", returns hostedKey (a config-key prefix);
-// otherwise returns the user-provided URL or path verbatim.
+// ResolveSource returns the source token to pass to GetRawData. The "config"
+// default and the legacy "hosted" alias both resolve to the provider's config
+// key; URLs and paths are returned verbatim.
 func ResolveSource(hostedKey string) string {
 	src := viper.GetString("source")
-	if src == "hosted" {
+	if src == "config" || src == "hosted" {
 		return hostedKey
 	}
 	return src
+}
+
+// IsConfiguredSource reports whether source names a provider whose endpoint or
+// local-file settings should be read from viper. Everything else that is not an
+// HTTP(S) URL is treated as a local path, including a bare filename.
+func IsConfiguredSource(source string) bool {
+	if _, ok := DefaultEndpoints[source]; ok {
+		return true
+	}
+	return viper.IsSet(source+"_endpoint") || viper.IsSet(source+"_local_file")
 }
 
 func ContainsIgnoreCase(slice []string, item string) bool {
@@ -63,6 +73,11 @@ func IsIPv4(s string) bool {
 func IsIPv6(s string) bool {
 	addr := parseIP(s)
 	return addr.IsValid() && addr.Is6()
+}
+
+func IsCIDR(s string) bool {
+	_, err := netip.ParsePrefix(s)
+	return err == nil
 }
 
 // DedupeSorted returns the input with empty entries dropped and the

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -10,6 +10,9 @@ import (
 func TestResolveSource(t *testing.T) {
 	t.Cleanup(func() { viper.Reset() })
 
+	viper.Set("source", "config")
+	assert.Equal(t, "aws", ResolveSource("aws"))
+
 	viper.Set("source", "hosted")
 	assert.Equal(t, "aws", ResolveSource("aws"))
 	assert.Equal(t, "cloudflare_ipv6", ResolveSource("cloudflare_ipv6"))
@@ -19,6 +22,9 @@ func TestResolveSource(t *testing.T) {
 
 	viper.Set("source", "/tmp/local.csv")
 	assert.Equal(t, "/tmp/local.csv", ResolveSource("aws"))
+
+	viper.Set("source", "ranges.csv")
+	assert.Equal(t, "ranges.csv", ResolveSource("aws"))
 }
 
 func TestContainsIgnoreCase(t *testing.T) {
@@ -61,4 +67,11 @@ func TestIPFamily(t *testing.T) {
 			assert.Equal(t, c.v6, IsIPv6(c.input), "IsIPv6(%q)", c.input)
 		})
 	}
+}
+
+func TestIsCIDR(t *testing.T) {
+	assert.True(t, IsCIDR("1.2.3.0/24"))
+	assert.True(t, IsCIDR("2606:4700::/32"))
+	assert.False(t, IsCIDR("1.2.3.4"))
+	assert.False(t, IsCIDR("not-an-ip"))
 }

--- a/internal/utils/raw_data_handler.go
+++ b/internal/utils/raw_data_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -22,15 +23,20 @@ const defaultCacheTTL = 24 * time.Hour
 const maxResponseBytes = 64 << 20
 
 // GetRawData fetches IP-range data for the given source. The source may be
-// a config-key prefix (e.g. "aws", looked up in viper), an http(s) URL, or
+// a config-key prefix (e.g. "aws", looked up in viper), an HTTP(S) URL, or
 // a filesystem path.
 func GetRawData(ctx context.Context, source string) (string, error) {
 	var endpointURL, localFile, cacheKey string
 
 	switch {
+	case source == "":
+		return "", fmt.Errorf("source cannot be empty")
 	case strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://"):
+		if err := ValidateHTTPURL(source); err != nil {
+			return "", err
+		}
 		endpointURL = source
-	case isHostedKey(source):
+	case IsConfiguredSource(source):
 		endpointURL = viper.GetString(source + "_endpoint")
 		localFile = viper.GetString(source + "_local_file")
 		if endpointURL == "" && localFile == "" {
@@ -39,6 +45,8 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 		if localFile == "" {
 			cacheKey = source
 		}
+	case strings.Contains(source, "://"):
+		return "", ValidateHTTPURL(source)
 	default:
 		localFile = source
 	}
@@ -51,11 +59,27 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 	if endpointURL == "" {
 		return "", fmt.Errorf("no endpoint URL or local file specified for source %q", source)
 	}
+	if err := ValidateHTTPURL(endpointURL); err != nil {
+		return "", fmt.Errorf("invalid endpoint for source %q: %w", source, err)
+	}
 
 	return GetCached(ctx, cacheKey, func(ctx context.Context) (string, error) {
 		fmt.Fprintln(os.Stderr, "Fetching IP ranges from endpoint:", endpointURL)
 		return loadFromEndpoint(ctx, endpointURL)
 	})
+}
+
+// ValidateHTTPURL verifies that rawURL is an absolute HTTP(S) URL suitable for
+// endpoint fetching.
+func ValidateHTTPURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid source URL %q", rawURL)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported source URL scheme %q (only http and https are supported)", parsed.Scheme)
+	}
+	return nil
 }
 
 func loadFromFile(filePath string) (string, error) {
@@ -88,13 +112,6 @@ func loadFromEndpoint(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("read body from %s: %w", url, err)
 	}
 	return string(body), nil
-}
-
-func isHostedKey(source string) bool {
-	if _, ok := DefaultEndpoints[source]; ok {
-		return true
-	}
-	return viper.IsSet(source+"_endpoint") || viper.IsSet(source+"_local_file")
 }
 
 func readAllLimited(r io.Reader, limit int64) ([]byte, error) {

--- a/internal/utils/raw_data_handler_test.go
+++ b/internal/utils/raw_data_handler_test.go
@@ -105,6 +105,38 @@ func TestGetRawData_LocalPath(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestGetRawData_BareFilename(t *testing.T) {
+	dir := t.TempDir()
+	oldWorkingDir, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+
+	want := "from-bare-filename"
+	assert.NoError(t, os.WriteFile("ranges.txt", []byte(want), 0o644))
+	got, err := GetRawData(context.Background(), "ranges.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestGetRawData_UnsupportedURLScheme(t *testing.T) {
+	_, err := GetRawData(context.Background(), "ftp://example.com/ranges.txt")
+	assert.ErrorContains(t, err, "unsupported source URL scheme")
+}
+
+func TestGetRawData_InvalidURL(t *testing.T) {
+	_, err := GetRawData(context.Background(), "https://")
+	assert.ErrorContains(t, err, "invalid source URL")
+}
+
+func TestGetRawData_UnsupportedConfiguredEndpointScheme(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	viper.Set("testprovider_endpoint", "ftp://example.com/ranges.txt")
+
+	_, err := GetRawData(context.Background(), "testprovider")
+	assert.ErrorContains(t, err, "unsupported source URL scheme")
+}
+
 func TestGetRawData_ViperKey(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 	t.Cleanup(func() { viper.Reset() })

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+BIN="$WORK_DIR/cipr"
+
+(
+    cd "$ROOT_DIR"
+    go build -o "$BIN" .
+)
+
+export HOME="$WORK_DIR/home"
+export XDG_CACHE_HOME="$WORK_DIR/cache"
+mkdir -p "$HOME" "$XDG_CACHE_HOME"
+
+run_and_expect() {
+    local name=$1
+    local expected=$2
+    shift 2
+
+    local output="$WORK_DIR/${name}.out"
+    "$BIN" "$@" >"$output"
+    if ! grep -Fq -- "$expected" "$output"; then
+        echo "Smoke test '$name' did not contain expected output: $expected" >&2
+        return 1
+    fi
+}
+
+run_and_expect help 'default "config"' --help
+run_and_expect aws "44.192.140.112/28" aws \
+    --source "$ROOT_DIR/internal/testdata/mock_ip_ranges_response.json" \
+    --ipv4 --filter-region us-east-1 --filter-service EBS \
+    --filter-network-border-group us-east-1
+run_and_expect azure "13.66.143.220/30" azure \
+    --source "$ROOT_DIR/internal/testdata/azure_servicetags_sample.json" --ipv4
+run_and_expect cloudflare-v4 "173.245.48.0/20" cloudflare \
+    --source "$ROOT_DIR/internal/testdata/cloudflare_ipv4.txt" --ipv4
+run_and_expect cloudflare-v6 "2400:cb00::/32" cloudflare \
+    --source "$ROOT_DIR/internal/testdata/cloudflare_ipv6.txt" --ipv6
+run_and_expect digitalocean "5.101.96.0/21" do \
+    --source "$ROOT_DIR/internal/testdata/do.csv" --ipv4 \
+    --filter-country NL --filter-city Amsterdam
+run_and_expect github "192.30.252.0/22" github \
+    --source "$ROOT_DIR/internal/testdata/github_meta_sample.json" --ipv4 \
+    --filter-service web
+run_and_expect icloud "172.224.224.0/27" icloud \
+    --source "$ROOT_DIR/internal/testdata/icloud.csv" --ipv4 \
+    --filter-country GB --filter-city London
+
+UNINSTALL_HOME="$WORK_DIR/uninstall-home"
+mkdir -p "$UNINSTALL_HOME/.cipr/bin" "$UNINSTALL_HOME/.config/cipr" "$UNINSTALL_HOME/.cache/cipr"
+cp "$BIN" "$UNINSTALL_HOME/.cipr/bin/cipr"
+touch "$UNINSTALL_HOME/.config/cipr/cipr.toml"
+touch "$UNINSTALL_HOME/.cache/cipr/ranges.cache"
+HOME="$UNINSTALL_HOME" "$ROOT_DIR/uninstall.sh" >"$WORK_DIR/uninstall.out"
+
+test ! -e "$UNINSTALL_HOME/.cipr/bin/cipr"
+test ! -e "$UNINSTALL_HOME/.config/cipr"
+test -e "$UNINSTALL_HOME/.cache/cipr/ranges.cache"
+
+CONFIG_ONLY_HOME="$WORK_DIR/config-only-home"
+mkdir -p "$CONFIG_ONLY_HOME/.config/cipr"
+touch "$CONFIG_ONLY_HOME/.config/cipr/cipr.toml"
+HOME="$CONFIG_ONLY_HOME" "$ROOT_DIR/uninstall.sh" >"$WORK_DIR/uninstall-config-only.out"
+test ! -e "$CONFIG_ONLY_HOME/.config/cipr"
+
+echo "Smoke tests passed."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,20 +4,26 @@ set -e
 
 INSTALL_DIR="$HOME/.cipr/bin"
 CIPR_PATH="$INSTALL_DIR/cipr"
+CONFIG_DIR="$HOME/.config/cipr"
 
-if [ ! -f "$CIPR_PATH" ]; then
+if [ -f "$CIPR_PATH" ]; then
+    rm "$CIPR_PATH"
+    echo "Removed cipr binary: $CIPR_PATH"
+else
     echo "cipr is not installed in $INSTALL_DIR."
-    exit 0
 fi
 
-rm "$CIPR_PATH"
-
-if [ -z "$(ls -A "$INSTALL_DIR")" ]; then
-    rm -rf "$INSTALL_DIR"
+if [ -d "$INSTALL_DIR" ] && [ -z "$(ls -A "$INSTALL_DIR")" ]; then
+    rmdir "$INSTALL_DIR"
     echo "Removed empty directory: $INSTALL_DIR"
 fi
 
-echo "cipr has been successfully uninstalled."
+if [ -d "$CONFIG_DIR" ]; then
+    rm -rf "$CONFIG_DIR"
+    echo "Removed cipr configuration: $CONFIG_DIR"
+else
+    echo "No cipr configuration found in $CONFIG_DIR."
+fi
 
 echo "Please remember to remove the following line from your shell configuration file (e.g., .bashrc, .zshrc):"
 echo "export PATH=\"\$HOME/.cipr/bin:\$PATH\""


### PR DESCRIPTION
## Summary
- rename the default source token to `config` while preserving `hosted` compatibility
- validate provider payload structure and CIDRs before filtering or printing
- remove cipr configuration during script uninstall
- add fixture-backed CLI smoke tests on Linux and macOS

## Verification
- `go build ./...`
- `go test ./...`
- `golangci-lint run`
- `./scripts/smoke-test.sh`

Closes #35
Closes #43
Closes #45
Closes #47