### PR TITLE
feat: add configuration and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ brew install cipr
 >
 > Documentation available at: [cipr.kaumnen.com](https://cipr.kaumnen.com/docs/intro)
 
+## Configuration and diagnostics
+
+cipr creates `$HOME/.config/cipr/cipr.toml` on first use. Inspect all managed
+settings with `cipr configure`, or target one source key:
+
+```bash
+cipr configure aws --endpoint https://example.com/aws-ranges.json
+cipr configure azure --local-file /path/to/azure-ranges.json --cache-ttl 0s
+cipr configure cloudflare_ipv4
+```
+
+`--proxy` supplies an HTTP(S) proxy for all network requests. When it is not
+set, cipr uses the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+environment variables. `--debug` writes source, cache, proxy, and HTTP
+diagnostics to stderr without changing IP-range output.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first

--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -20,7 +20,7 @@ var cloudflareCmd = &cobra.Command{
 
 		ipv4 := viper.GetBool("cloudflare_ipv4")
 		ipv6 := viper.GetBool("cloudflare_ipv6")
-		if viper.GetString("source") != "hosted" {
+		if !usesConfiguredSources(viper.GetString("source")) {
 			return cloudflare.GetIPRanges(cmd.Context(), cloudflare.Config{
 				Source: utils.ResolveSource("cloudflare"), Verbosity: verbosity,
 			})
@@ -45,6 +45,10 @@ var cloudflareCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func usesConfiguredSources(source string) bool {
+	return source == "config" || source == "hosted"
 }
 
 func init() {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,0 +1,357 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kaumnen/cipr/internal/utils"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const defaultConfiguredCacheTTL = "24h"
+
+var configureCmd = &cobra.Command{
+	Use:   "configure [source-key]",
+	Short: "Show or update cipr configuration",
+	Long: `Show or update cipr's managed configuration values.
+
+Source-specific settings use the keys written to cipr.toml, including aws,
+azure, cloudflare_ipv4, cloudflare_ipv6, digitalocean, github, and icloud.
+With no update flags, the effective managed configuration is displayed.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runConfigure,
+}
+
+func init() {
+	rootCmd.AddCommand(configureCmd)
+	configureCmd.Flags().String("endpoint", "", "HTTP(S) endpoint for the selected source (empty resets to the default)")
+	configureCmd.Flags().String("local-file", "", "Local data file for the selected source (empty clears the override)")
+	configureCmd.Flags().String("cache-ttl", "", "Cache duration for the selected source (empty resets to 24h; 0s disables caching)")
+}
+
+func runConfigure(cmd *cobra.Command, args []string) error {
+	var source string
+	if len(args) == 1 {
+		source = args[0]
+		if _, ok := utils.DefaultEndpoints[source]; !ok {
+			return fmt.Errorf("unknown source key %q (valid: %s)", source, strings.Join(configuredSourceKeys(), ", "))
+		}
+	}
+
+	endpointChanged := cmd.Flags().Changed("endpoint")
+	localFileChanged := cmd.Flags().Changed("local-file")
+	cacheTTLChanged := cmd.Flags().Changed("cache-ttl")
+	proxyChanged := cmd.Flags().Changed("proxy")
+	debugChanged := cmd.Flags().Changed("debug")
+
+	if (endpointChanged || localFileChanged || cacheTTLChanged) && source == "" {
+		return fmt.Errorf("a source key is required with --endpoint, --local-file, or --cache-ttl")
+	}
+	if endpointChanged && localFileChanged {
+		return fmt.Errorf("--endpoint and --local-file cannot be changed together")
+	}
+
+	updates := make(map[string]any)
+	if endpointChanged {
+		endpoint, err := cmd.Flags().GetString("endpoint")
+		if err != nil {
+			return err
+		}
+		if endpoint == "" {
+			endpoint = utils.DefaultEndpoints[source]
+		}
+		if err := utils.ValidateHTTPURL(endpoint); err != nil {
+			return err
+		}
+		updates[source+"_endpoint"] = endpoint
+		updates[source+"_local_file"] = ""
+	}
+	if localFileChanged {
+		localFile, err := cmd.Flags().GetString("local-file")
+		if err != nil {
+			return err
+		}
+		updates[source+"_local_file"] = localFile
+	}
+	if cacheTTLChanged {
+		cacheTTL, err := cmd.Flags().GetString("cache-ttl")
+		if err != nil {
+			return err
+		}
+		if cacheTTL == "" {
+			cacheTTL = defaultConfiguredCacheTTL
+		}
+		duration, err := time.ParseDuration(cacheTTL)
+		if err != nil || duration < 0 {
+			return fmt.Errorf("invalid cache TTL %q (use a non-negative Go duration such as 24h or 0s)", cacheTTL)
+		}
+		updates[source+"_cache_ttl"] = cacheTTL
+	}
+	if proxyChanged {
+		proxy, err := cmd.Flags().GetString("proxy")
+		if err != nil {
+			return err
+		}
+		if err := utils.ValidateProxyURL(proxy); err != nil {
+			return err
+		}
+		updates["proxy"] = proxy
+	}
+	if debugChanged {
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		updates["debug"] = debug
+	}
+
+	if len(updates) > 0 {
+		configPath := viper.ConfigFileUsed()
+		if configPath == "" {
+			return fmt.Errorf("cannot determine active config file")
+		}
+		if err := updateConfigValues(configPath, updates); err != nil {
+			return err
+		}
+		if err := viper.ReadInConfig(); err != nil {
+			return fmt.Errorf("reload config file: %w", err)
+		}
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Updated config file:", configPath); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+	}
+
+	return showEffectiveConfiguration(cmd.OutOrStdout(), source)
+}
+
+func configuredSourceKeys() []string {
+	keys := make([]string, 0, len(utils.DefaultEndpoints))
+	for key := range utils.DefaultEndpoints {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func showEffectiveConfiguration(w io.Writer, selectedSource string) error {
+	if _, err := fmt.Fprintf(w, "config_file = %q\n", viper.ConfigFileUsed()); err != nil {
+		return fmt.Errorf("write configuration output: %w", err)
+	}
+	proxy := viper.GetString("proxy")
+	if proxy != "" {
+		proxy = utils.SanitizeURL(proxy)
+	} else if hasProxyEnvironment() {
+		proxy = "<environment>"
+	}
+	if _, err := fmt.Fprintf(w, "proxy = %q\n", proxy); err != nil {
+		return fmt.Errorf("write configuration output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "debug = %t\n", viper.GetBool("debug")); err != nil {
+		return fmt.Errorf("write configuration output: %w", err)
+	}
+
+	keys := configuredSourceKeys()
+	if selectedSource != "" {
+		keys = []string{selectedSource}
+	}
+	for _, source := range keys {
+		endpoint := viper.GetString(source + "_endpoint")
+		if endpoint == "" {
+			endpoint = utils.DefaultEndpoints[source]
+		}
+		localFile := viper.GetString(source + "_local_file")
+		cacheTTL := viper.GetString(source + "_cache_ttl")
+		if parsed, err := time.ParseDuration(cacheTTL); cacheTTL == "" || err != nil || parsed < 0 {
+			cacheTTL = defaultConfiguredCacheTTL
+		}
+		active := "endpoint"
+		if localFile != "" {
+			active = "local-file"
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+		if _, err := fmt.Fprintf(w, "%s_active_source = %q\n", source, active); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+		if _, err := fmt.Fprintf(w, "%s_endpoint = %q\n", source, endpoint); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+		if _, err := fmt.Fprintf(w, "%s_local_file = %q\n", source, localFile); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+		if _, err := fmt.Fprintf(w, "%s_cache_ttl = %q\n", source, cacheTTL); err != nil {
+			return fmt.Errorf("write configuration output: %w", err)
+		}
+	}
+	return nil
+}
+
+func hasProxyEnvironment() bool {
+	for _, key := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func updateConfigValues(configPath string, updates map[string]any) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config file: %w", err)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return fmt.Errorf("inspect config file: %w", err)
+	}
+
+	assignments := make(map[string]string, len(updates))
+	for key, value := range updates {
+		encoded, err := toml.Marshal(map[string]any{key: value})
+		if err != nil {
+			return fmt.Errorf("encode config value %s: %w", key, err)
+		}
+		assignments[key] = strings.TrimSpace(string(encoded))
+	}
+
+	lines := strings.Split(string(data), "\n")
+	missing := make(map[string]struct{}, len(assignments))
+	for key := range assignments {
+		missing[key] = struct{}{}
+	}
+	firstTable := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			firstTable = i
+			break
+		}
+		key, ok := assignmentKey(line)
+		if !ok {
+			continue
+		}
+		assignment, managed := assignments[key]
+		if !managed {
+			continue
+		}
+		indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		if comment := inlineAssignmentComment(line); comment != "" {
+			assignment += " " + comment
+		}
+		lines[i] = indent + assignment
+		delete(missing, key)
+	}
+
+	if len(missing) > 0 {
+		keys := make([]string, 0, len(missing))
+		for key := range missing {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		block := make([]string, 0, len(keys)+2)
+		for _, key := range keys {
+			block = append(block, assignments[key])
+		}
+
+		insertAt := firstTable
+		if insertAt < 0 {
+			insertAt = len(lines)
+			if insertAt > 0 && lines[insertAt-1] == "" {
+				insertAt--
+			}
+		}
+		if insertAt > 0 && strings.TrimSpace(lines[insertAt-1]) != "" {
+			block = append([]string{""}, block...)
+		}
+		if insertAt < len(lines) && strings.TrimSpace(lines[insertAt]) != "" {
+			block = append(block, "")
+		}
+		lines = append(lines[:insertAt], append(block, lines[insertAt:]...)...)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(configPath), filepath.Base(configPath)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create config temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		return fmt.Errorf("preserve config permissions: %w", err)
+	}
+	if _, err := tmp.WriteString(strings.Join(lines, "\n")); err != nil {
+		return fmt.Errorf("write config temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync config temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close config temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		return fmt.Errorf("replace config file: %w", err)
+	}
+	return nil
+}
+
+func assignmentKey(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", false
+	}
+	equals := strings.IndexByte(trimmed, '=')
+	if equals < 1 {
+		return "", false
+	}
+	key := strings.TrimSpace(trimmed[:equals])
+	for _, r := range key {
+		if r != '_' && r != '-' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+			return "", false
+		}
+	}
+	return key, true
+}
+
+func inlineAssignmentComment(line string) string {
+	equals := strings.IndexByte(line, '=')
+	if equals < 0 {
+		return ""
+	}
+	inBasic, inLiteral, escaped := false, false, false
+	for i := equals + 1; i < len(line); i++ {
+		char := line[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inBasic && char == '\\' {
+			escaped = true
+			continue
+		}
+		switch char {
+		case '"':
+			if !inLiteral {
+				inBasic = !inBasic
+			}
+		case '\'':
+			if !inBasic {
+				inLiteral = !inLiteral
+			}
+		case '#':
+			if !inBasic && !inLiteral {
+				return strings.TrimSpace(line[i:])
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateConfigValuesPreservesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cipr.toml")
+	original := `# keep this comment
+proxy = "http://old.example" # keep inline comment
+aws_endpoint = "https://old.example/ranges"
+custom_key = "untouched"
+
+[custom]
+debug = "section value"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o640))
+
+	err := updateConfigValues(path, map[string]any{
+		"aws_endpoint": "https://new.example/ranges#fragment",
+		"debug":        true,
+		"proxy":        "http://proxy.example:8080",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	text := string(data)
+	assert.Contains(t, text, "# keep this comment")
+	assert.Contains(t, text, `proxy = 'http://proxy.example:8080' # keep inline comment`)
+	assert.Contains(t, text, `aws_endpoint = 'https://new.example/ranges#fragment'`)
+	assert.Contains(t, text, `custom_key = "untouched"`)
+	assert.Contains(t, text, "debug = true\n\n[custom]")
+	assert.Contains(t, text, `debug = "section value"`)
+
+	var decoded map[string]any
+	require.NoError(t, toml.Unmarshal(data, &decoded))
+	assert.Equal(t, true, decoded["debug"])
+	assert.Equal(t, "untouched", decoded["custom_key"])
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+}
+
+func TestUpdateConfigValuesValidationFailureDoesNotChangeFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cipr.toml")
+	original := []byte("proxy = \"\"\n")
+	require.NoError(t, os.WriteFile(path, original, 0o600))
+
+	err := updateConfigValues(path, map[string]any{"proxy": make(chan int)})
+	require.Error(t, err)
+
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, got)
+}
+
+func TestInlineAssignmentCommentIgnoresHashesInsideStrings(t *testing.T) {
+	assert.Empty(t, inlineAssignmentComment(`endpoint = "https://example.test/#fragment"`))
+	assert.Equal(t, "# comment", inlineAssignmentComment(`endpoint = "https://example.test/#fragment" # comment`))
+}
+
+func TestConfiguredSourceKeysAreSorted(t *testing.T) {
+	keys := configuredSourceKeys()
+	assert.True(t, strings.Contains(strings.Join(keys, ","), "cloudflare_ipv4"))
+	assert.True(t, sort.StringsAreSorted(keys))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,15 @@ var rootCmd = &cobra.Command{
 	Short:        "Retrieve IP ranges from cloud providers and services",
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return initConfig()
+		if err := initConfig(cmd); err != nil {
+			return err
+		}
+		utils.SetDebug(viper.GetBool("debug"))
+		utils.Debugf("config: using %s", viper.ConfigFileUsed())
+		if err := utils.ValidateProxyURL(viper.GetString("proxy")); err != nil {
+			return err
+		}
+		return nil
 	},
 	Long: `cipr is a CLI tool for retrieving IP ranges from various cloud providers
 and services (AWS, Azure, Cloudflare, DigitalOcean, GitHub, iCloud Private Relay).
@@ -51,32 +59,33 @@ func init() {
 	rootCmd.PersistentFlags().String("verbose-mode", "none", "Verbosity level: none, mini, full. Overrides --verbose")
 	rootCmd.PersistentFlags().String("source", "config", "Data source: config, an HTTP(S) URL, or a local file path")
 	rootCmd.PersistentFlags().Bool("no-cache", false, "Bypass cache (skip read and write)")
+	rootCmd.PersistentFlags().String("proxy", "", "HTTP(S) proxy URL (defaults to standard proxy environment variables)")
+	rootCmd.PersistentFlags().Bool("debug", false, "Enable diagnostic logging on stderr")
 
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	viper.BindPFlag("verbose_mode", rootCmd.PersistentFlags().Lookup("verbose-mode"))
 	viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
 	viper.BindPFlag("no_cache", rootCmd.PersistentFlags().Lookup("no-cache"))
+	viper.BindPFlag("proxy", rootCmd.PersistentFlags().Lookup("proxy"))
+	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 }
 
-func initConfig() error {
+func initConfig(cmd *cobra.Command) error {
+	var configPath string
 	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
+		configPath = cfgFile
 	} else {
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
 
-		configPath := filepath.Join(home, ".config", "cipr", "cipr.toml")
-		viper.SetConfigFile(configPath)
-		viper.SetConfigType("toml")
+		configPath = filepath.Join(home, ".config", "cipr", "cipr.toml")
+	}
+	viper.SetConfigFile(configPath)
+	viper.SetConfigType("toml")
 
-		if _, err := os.Stat(configPath); os.IsNotExist(err) {
-			if err := createDefaultConfig(configPath); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return fmt.Errorf("inspect config file: %w", err)
-		}
+	if err := ensureConfigFile(configPath, cfgFile == "" || cmd.Name() == configureCmd.Name()); err != nil {
+		return err
 	}
 
 	viper.AutomaticEnv()
@@ -85,6 +94,20 @@ func initConfig() error {
 		return fmt.Errorf("read config file: %w", err)
 	}
 	return nil
+}
+
+func ensureConfigFile(configPath string, createIfMissing bool) error {
+	_, err := os.Stat(configPath)
+	switch {
+	case err == nil:
+		return nil
+	case os.IsNotExist(err) && createIfMissing:
+		return createDefaultConfig(configPath)
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return fmt.Errorf("inspect config file: %w", err)
+	}
 }
 
 func resolveVerbosity(cmd *cobra.Command) (string, error) {
@@ -145,6 +168,9 @@ func createDefaultConfig(configPath string) error {
 #   <provider>_cache_ttl  = how long to reuse a cached hosted response. Go duration
 #                           string ("24h", "30m"). "0s" disables caching for this
 #                           provider; defaults to 24h if unset or unparseable.
+
+proxy = ""
+debug = false
 
 `
 	if _, err := fmt.Fprint(file, header); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -45,4 +47,30 @@ func TestResolveVerbosityRejectsInvalidValue(t *testing.T) {
 
 	_, err := resolveVerbosity(&cobra.Command{})
 	require.Error(t, err)
+}
+
+func TestEnsureConfigFileCreatesDefaultsForConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "cipr.toml")
+	require.NoError(t, ensureConfigFile(path, true))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	text := string(data)
+	assert.Contains(t, text, `proxy = ""`)
+	assert.Contains(t, text, "debug = false")
+	assert.Contains(t, text, "cloudflare_ipv4_endpoint")
+}
+
+func TestEnsureConfigFileLeavesMissingCustomConfigForNormalCommands(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.toml")
+	require.NoError(t, ensureConfigFile(path, false))
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestUsesConfiguredSources(t *testing.T) {
+	assert.True(t, usesConfiguredSources("config"))
+	assert.True(t, usesConfiguredSources("hosted"))
+	assert.False(t, usesConfiguredSources("https://example.test/ranges"))
+	assert.False(t, usesConfiguredSources("ranges.txt"))
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kaumnen/cipr
 go 1.26
 
 require (
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -13,7 +14,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/internal/azure/logic.go
+++ b/internal/azure/logic.go
@@ -167,14 +167,20 @@ func scrapeJSONURL(ctx context.Context, pageURL string) (string, error) {
 	}
 	req.Header.Set("User-Agent", browserUA)
 
-	fmt.Fprintln(os.Stderr, "Resolving Azure ServiceTags JSON URL from:", pageURL)
+	fmt.Fprintln(os.Stderr, "Resolving Azure ServiceTags JSON URL from:", utils.SanitizeURL(pageURL))
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client, err := utils.NewHTTPClient()
+	if err != nil {
+		return "", err
+	}
+	started := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		utils.Debugf("http: GET %s failed after %s", utils.SanitizeURL(pageURL), time.Since(started).Round(time.Millisecond))
 		return "", fmt.Errorf("fetch %s: %w", pageURL, err)
 	}
 	defer resp.Body.Close()
+	utils.Debugf("http: GET %s returned %d after %s", utils.SanitizeURL(pageURL), resp.StatusCode, time.Since(started).Round(time.Millisecond))
 
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, pageURL)
@@ -187,6 +193,7 @@ func scrapeJSONURL(ctx context.Context, pageURL string) (string, error) {
 	if len(body) > maxAzurePageBytes {
 		return "", fmt.Errorf("page from %s exceeds %d byte limit", pageURL, maxAzurePageBytes)
 	}
+	utils.Debugf("http: read %d bytes from %s", len(body), utils.SanitizeURL(pageURL))
 
 	match := jsonURLRegex.FindString(string(body))
 	if match == "" {

--- a/internal/azure/logic_test.go
+++ b/internal/azure/logic_test.go
@@ -370,3 +370,23 @@ func TestFetchRawData_NoCacheBypass(t *testing.T) {
 	}
 	assert.Equal(t, 2, hits, "--no-cache should refetch every call")
 }
+
+func TestScrapeJSONURLUsesConfiguredProxy(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+
+	const pageURL = "http://azure.example/download/details.aspx?id=56519"
+	const want = "https://download.microsoft.com/test/ServiceTags_Public_20260101.json"
+	var hits int
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		assert.Equal(t, pageURL, r.URL.String())
+		_, _ = w.Write([]byte(`<html><a href="` + want + `">download</a></html>`))
+	}))
+	defer proxy.Close()
+	viper.Set("proxy", proxy.URL)
+
+	got, err := scrapeJSONURL(context.Background(), pageURL)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.Equal(t, 1, hits)
+}

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -17,15 +17,24 @@ import (
 // failures are logged but never fatal. Suitable for providers (e.g. azure)
 // whose fetch path doesn't reduce to a single utils.GetRawData call.
 func GetCached(ctx context.Context, key string, fetch func(context.Context) (string, error)) (string, error) {
-	if key == "" || viper.GetBool("no_cache") {
+	if key == "" {
+		Debugf("cache: bypassed for unkeyed source")
+		return fetch(ctx)
+	}
+	if viper.GetBool("no_cache") {
+		Debugf("cache: bypassed for %s by configuration", key)
 		return fetch(ctx)
 	}
 	ttl := resolveCacheTTL(key)
 	if ttl > 0 {
 		if data, ok, _ := readCache(key, ttl); ok {
+			Debugf("cache: hit for %s (age %s, ttl %s)", key, cacheAge(key), ttl)
 			fmt.Fprintf(os.Stderr, "Using cached IP ranges for %s (age %s)\n", key, cacheAge(key))
 			return string(data), nil
 		}
+		Debugf("cache: miss or stale entry for %s (ttl %s)", key, ttl)
+	} else {
+		Debugf("cache: disabled for %s", key)
 	}
 	body, err := fetch(ctx)
 	if err != nil {
@@ -33,6 +42,9 @@ func GetCached(ctx context.Context, key string, fetch func(context.Context) (str
 	}
 	if werr := writeCache(key, []byte(body)); werr != nil {
 		fmt.Fprintln(os.Stderr, "Warning: cache write failed:", werr)
+		Debugf("cache: write failed for %s: %v", key, werr)
+	} else {
+		Debugf("cache: wrote %d bytes for %s", len(body), key)
 	}
 	return body, nil
 }

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sync"
+)
+
+var debugState = struct {
+	sync.Mutex
+	enabled bool
+	output  io.Writer
+}{output: os.Stderr}
+
+// SetDebug enables or disables diagnostic logging. Debug messages always go
+// to stderr unless tests replace the writer with setDebugWriter.
+func SetDebug(enabled bool) {
+	debugState.Lock()
+	defer debugState.Unlock()
+	debugState.enabled = enabled
+}
+
+// Debugf writes a diagnostic message when debug logging is enabled.
+func Debugf(format string, args ...any) {
+	debugState.Lock()
+	defer debugState.Unlock()
+	if !debugState.enabled {
+		return
+	}
+	_, _ = fmt.Fprintf(debugState.output, "[debug] "+format+"\n", args...)
+}
+
+func setDebugWriter(w io.Writer) func() {
+	debugState.Lock()
+	previous := debugState.output
+	debugState.output = w
+	debugState.Unlock()
+	return func() {
+		debugState.Lock()
+		debugState.output = previous
+		debugState.Unlock()
+	}
+}
+
+// SanitizeURL removes URL components that commonly carry credentials or
+// tokens before the URL is written to debug output.
+func SanitizeURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword("xxxxx", "xxxxx")
+		} else {
+			parsed.User = url.User("xxxxx")
+		}
+	}
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/utils/http_client.go
+++ b/internal/utils/http_client.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const httpTimeout = 30 * time.Second
+
+// ValidateProxyURL verifies that rawURL is an absolute HTTP(S) proxy URL.
+// An empty value is valid and means that the standard proxy environment
+// variables should be used.
+func ValidateProxyURL(rawURL string) error {
+	if rawURL == "" {
+		return nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid proxy URL %q", rawURL)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported proxy URL scheme %q (only http and https are supported)", parsed.Scheme)
+	}
+	return nil
+}
+
+// NewHTTPClient returns a client configured from the effective proxy setting.
+// A configured proxy overrides the standard environment proxy. With no
+// configured value, ProxyFromEnvironment supplies HTTP_PROXY, HTTPS_PROXY,
+// and NO_PROXY behavior.
+func NewHTTPClient() (*http.Client, error) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unsupported default HTTP transport %T", http.DefaultTransport)
+	}
+	cloned := transport.Clone()
+
+	configured := viper.GetString("proxy")
+	if err := ValidateProxyURL(configured); err != nil {
+		return nil, err
+	}
+	if configured != "" {
+		proxyURL, _ := url.Parse(configured)
+		cloned.Proxy = func(req *http.Request) (*url.URL, error) {
+			Debugf("proxy: configured %s for %s", SanitizeURL(configured), SanitizeURL(req.URL.String()))
+			return proxyURL, nil
+		}
+	} else {
+		cloned.Proxy = func(req *http.Request) (*url.URL, error) {
+			proxyURL, err := http.ProxyFromEnvironment(req)
+			switch {
+			case err != nil:
+				Debugf("proxy: environment lookup failed for %s", SanitizeURL(req.URL.String()))
+			case proxyURL != nil:
+				Debugf("proxy: environment %s for %s", SanitizeURL(proxyURL.String()), SanitizeURL(req.URL.String()))
+			default:
+				Debugf("proxy: direct connection for %s", SanitizeURL(req.URL.String()))
+			}
+			return proxyURL, err
+		}
+	}
+
+	return &http.Client{Transport: cloned, Timeout: httpTimeout}, nil
+}

--- a/internal/utils/http_client_test.go
+++ b/internal/utils/http_client_test.go
@@ -1,0 +1,102 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProxyURL(t *testing.T) {
+	for _, valid := range []string{"", "http://proxy.example:8080", "https://user:pass@proxy.example"} {
+		assert.NoError(t, ValidateProxyURL(valid))
+	}
+	for _, invalid := range []string{"proxy.example:8080", "ftp://proxy.example", "https://"} {
+		assert.Error(t, ValidateProxyURL(invalid))
+	}
+}
+
+func TestConfiguredProxyRoutesEndpointRequest(t *testing.T) {
+	oldProxy := viper.Get("proxy")
+	t.Cleanup(func() { viper.Set("proxy", oldProxy) })
+
+	var requestedURL string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.String()
+		_, _ = w.Write([]byte("proxied response"))
+	}))
+	defer proxy.Close()
+	viper.Set("proxy", proxy.URL)
+
+	body, err := loadFromEndpoint(context.Background(), "http://upstream.invalid/ranges?token=secret")
+	require.NoError(t, err)
+	assert.Equal(t, "proxied response", body)
+	assert.Equal(t, "http://upstream.invalid/ranges?token=secret", requestedURL)
+}
+
+func TestHTTPClientFallsBackToProxyEnvironment(t *testing.T) {
+	oldProxy := viper.Get("proxy")
+	t.Cleanup(func() { viper.Set("proxy", oldProxy) })
+	viper.Set("proxy", "")
+
+	client, err := NewHTTPClient()
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/ranges", nil)
+	require.NoError(t, err)
+
+	transport := client.Transport.(*http.Transport)
+	got, gotErr := transport.Proxy(req)
+	want, wantErr := http.ProxyFromEnvironment(req)
+	assert.Equal(t, wantErr, gotErr)
+	if want == nil {
+		assert.Nil(t, got)
+	} else {
+		require.NotNil(t, got)
+		assert.Equal(t, want.String(), got.String())
+	}
+}
+
+func TestDebugHTTPLoggingRedactsSecrets(t *testing.T) {
+	oldProxy := viper.Get("proxy")
+	t.Cleanup(func() { viper.Set("proxy", oldProxy) })
+	viper.Set("proxy", "http://proxy-user:proxy-secret@proxy.example:8080")
+
+	var output bytes.Buffer
+	restoreWriter := setDebugWriter(&output)
+	t.Cleanup(restoreWriter)
+	SetDebug(true)
+	t.Cleanup(func() { SetDebug(false) })
+
+	client, err := NewHTTPClient()
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://endpoint-user:endpoint-secret@example.test/ranges?token=query-secret", nil)
+	require.NoError(t, err)
+	_, err = client.Transport.(*http.Transport).Proxy(req)
+	require.NoError(t, err)
+
+	log := output.String()
+	assert.Contains(t, log, "[debug] proxy: configured")
+	for _, secret := range []string{"proxy-user", "proxy-secret", "endpoint-user", "endpoint-secret", "query-secret"} {
+		assert.NotContains(t, log, secret)
+	}
+}
+
+func TestDebugDisabledProducesNoOutput(t *testing.T) {
+	var output bytes.Buffer
+	restoreWriter := setDebugWriter(&output)
+	t.Cleanup(restoreWriter)
+	SetDebug(false)
+
+	Debugf("secret diagnostic")
+	assert.Empty(t, output.String())
+}
+
+func TestSanitizeURL(t *testing.T) {
+	got := SanitizeURL("https://user:password@example.test/ranges?token=secret#fragment")
+	assert.Equal(t, "https://xxxxx:xxxxx@example.test/ranges", got)
+}

--- a/internal/utils/raw_data_handler.go
+++ b/internal/utils/raw_data_handler.go
@@ -17,8 +17,6 @@ import (
 // with the build version when one is set.
 var UserAgent = "cipr"
 
-var httpClient = &http.Client{Timeout: 30 * time.Second}
-
 const defaultCacheTTL = 24 * time.Hour
 const maxResponseBytes = 64 << 20
 
@@ -27,6 +25,7 @@ const maxResponseBytes = 64 << 20
 // a filesystem path.
 func GetRawData(ctx context.Context, source string) (string, error) {
 	var endpointURL, localFile, cacheKey string
+	sourceKind := ""
 
 	switch {
 	case source == "":
@@ -36,6 +35,7 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 			return "", err
 		}
 		endpointURL = source
+		sourceKind = "url"
 	case IsConfiguredSource(source):
 		endpointURL = viper.GetString(source + "_endpoint")
 		localFile = viper.GetString(source + "_local_file")
@@ -44,12 +44,21 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 		}
 		if localFile == "" {
 			cacheKey = source
+			sourceKind = "configured endpoint"
+		} else {
+			sourceKind = "configured local file"
 		}
 	case strings.Contains(source, "://"):
 		return "", ValidateHTTPURL(source)
 	default:
 		localFile = source
+		sourceKind = "local file"
 	}
+	debugSource := source
+	if strings.Contains(source, "://") {
+		debugSource = SanitizeURL(source)
+	}
+	Debugf("source: %q resolved as %s", debugSource, sourceKind)
 
 	if localFile != "" {
 		fmt.Fprintln(os.Stderr, "Fetching IP ranges from local file:", localFile)
@@ -64,7 +73,7 @@ func GetRawData(ctx context.Context, source string) (string, error) {
 	}
 
 	return GetCached(ctx, cacheKey, func(ctx context.Context) (string, error) {
-		fmt.Fprintln(os.Stderr, "Fetching IP ranges from endpoint:", endpointURL)
+		fmt.Fprintln(os.Stderr, "Fetching IP ranges from endpoint:", SanitizeURL(endpointURL))
 		return loadFromEndpoint(ctx, endpointURL)
 	})
 }
@@ -97,11 +106,18 @@ func loadFromEndpoint(ctx context.Context, url string) (string, error) {
 	}
 	req.Header.Set("User-Agent", UserAgent)
 
-	response, err := httpClient.Do(req)
+	client, err := NewHTTPClient()
 	if err != nil {
+		return "", err
+	}
+	started := time.Now()
+	response, err := client.Do(req)
+	if err != nil {
+		Debugf("http: GET %s failed after %s", SanitizeURL(url), time.Since(started).Round(time.Millisecond))
 		return "", fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer response.Body.Close()
+	Debugf("http: GET %s returned %d after %s", SanitizeURL(url), response.StatusCode, time.Since(started).Round(time.Millisecond))
 
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("unexpected status %d from %s", response.StatusCode, url)
@@ -111,6 +127,7 @@ func loadFromEndpoint(ctx context.Context, url string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read body from %s: %w", url, err)
 	}
+	Debugf("http: read %d bytes from %s", len(body), SanitizeURL(url))
 	return string(body), nil
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -51,6 +51,29 @@ run_and_expect icloud "172.224.224.0/27" icloud \
     --source "$ROOT_DIR/internal/testdata/icloud.csv" --ipv4 \
     --filter-country GB --filter-city London
 
+CONFIGURE_HOME="$WORK_DIR/configure-home"
+mkdir -p "$CONFIGURE_HOME"
+HOME="$CONFIGURE_HOME" "$BIN" configure aws \
+    --local-file "$ROOT_DIR/internal/testdata/aws.json" \
+    --cache-ttl 0s \
+    --proxy http://proxy.example:8080 \
+    --debug >"$WORK_DIR/configure.out" 2>"$WORK_DIR/configure.err"
+grep -Fq 'aws_active_source = "local-file"' "$WORK_DIR/configure.out"
+grep -Fq 'proxy = "http://proxy.example:8080"' "$WORK_DIR/configure.out"
+grep -Fq '[debug] config: using' "$WORK_DIR/configure.err"
+grep -Fq "aws_local_file = '$ROOT_DIR/internal/testdata/aws.json'" \
+    "$CONFIGURE_HOME/.config/cipr/cipr.toml"
+grep -Fq "aws_cache_ttl = '0s'" "$CONFIGURE_HOME/.config/cipr/cipr.toml"
+
+HOME="$CONFIGURE_HOME" "$BIN" configure aws --local-file= >"$WORK_DIR/configure-clear.out"
+grep -Fq 'aws_active_source = "endpoint"' "$WORK_DIR/configure-clear.out"
+
+CUSTOM_CONFIG="$WORK_DIR/custom-config/cipr.toml"
+HOME="$CONFIGURE_HOME" "$BIN" --config "$CUSTOM_CONFIG" configure github \
+    --cache-ttl 0s >"$WORK_DIR/configure-custom.out"
+test -f "$CUSTOM_CONFIG"
+grep -Fq "github_cache_ttl = '0s'" "$CUSTOM_CONFIG"
+
 UNINSTALL_HOME="$WORK_DIR/uninstall-home"
 mkdir -p "$UNINSTALL_HOME/.cipr/bin" "$UNINSTALL_HOME/.config/cipr" "$UNINSTALL_HOME/.cache/cipr"
 cp "$BIN" "$UNINSTALL_HOME/.cipr/bin/cipr"


### PR DESCRIPTION
## Summary

- add `cipr configure [source-key]` for displaying and safely updating managed TOML settings
- add global HTTP(S) proxy support for provider requests and Azure discovery
- add sanitized debug diagnostics for config, source, cache, proxy, and HTTP decisions
- fix Cloudflare's default `config` source handling while retaining the legacy `hosted` alias
- document the new CLI and expand unit and smoke coverage

## Why

Configuration previously required manual TOML editing, endpoint calls could not use an application-level proxy, and the existing verbosity flags controlled result formatting rather than runtime diagnostics. The Cloudflare command also still checked only the legacy `hosted` value after the default source changed to `config`.

## Impact

Users can inspect or update source settings through a scriptable command, override proxy behavior without replacing system environment variables, and troubleshoot fetch decisions without changing stdout. Existing configs remain compatible, comments and unrelated TOML keys are preserved, and sensitive URL components are redacted from diagnostics.

Closes #39
Closes #40
Closes #46

## Validation

- `go test ./...` — 218 tests passed across 9 packages
- `golangci-lint run` — no issues
- `./scripts/smoke-test.sh` — passed
