### PR TITLE
docs: update homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ cipr is a command-line interface (CLI) tool designed to simplify the process of 
 
 ## Installation
 
-To install cipr, you can use homebrew:
+To install cipr, you can use Homebrew:
 
 ```bash title='CLI command'
-brew tap kaumnen/tap
-brew install cipr
+brew install kaumnen/tap/cipr
 ```
 
 > [!NOTE]  


### PR DESCRIPTION
uses the fully qualified homebrew formula in the readme

keeps installation compatible with tap trust