### PR TITLE
feat: add google cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,41 +20,6 @@ brew install kaumnen/tap/cipr
 >
 > Documentation available at: [cipr.kaumnen.com](https://cipr.kaumnen.com/docs/intro)
 
-## Configuration and diagnostics
-
-cipr creates `$HOME/.config/cipr/cipr.toml` on first use. Inspect all managed
-settings with `cipr configure`, or target one source key:
-
-```bash
-cipr configure aws --endpoint https://example.com/aws-ranges.json
-cipr configure azure --local-file /path/to/azure-ranges.json --cache-ttl 0s
-cipr configure cloudflare_ipv4
-cipr configure gcp
-```
-
-`--proxy` supplies an HTTP(S) proxy for all network requests. When it is not
-set, cipr uses the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
-environment variables. `--debug` writes source, cache, proxy, and HTTP
-diagnostics to stderr without changing IP-range output.
-
-## Google Cloud
-
-The `gcp` provider reads Google's [`cloud.json`](https://www.gstatic.com/ipranges/cloud.json)
-feed of [global and regional external IP ranges](https://cloud.google.com/vpc/docs/access-apis-external-ip)
-available to Google Cloud customers. These are not project-specific allocations
-or the broader ranges used by Google APIs and services.
-
-```bash
-cipr gcp --ipv4 --filter-scope us-central1
-cipr gcp --ipv6 --filter 'global,Google Cloud' --verbose-mode mini
-cipr gcp --list scopes
-```
-
-Scopes are Google Cloud region names or `global`. The feed's `service` field is
-currently `Google Cloud`; it does not identify individual products or APIs.
-Google updates the feed frequently. Use `--no-cache` when a fresh fetch is
-required instead of the default 24-hour cached copy.
-
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/kaumnen/cipr/releaser.yml)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/kaumnen/cipr)
 
-cipr is a command-line interface (CLI) tool designed to simplify the process of retrieving IP ranges from various cloud providers and services. It provides a quick and efficient way to access up-to-date IP ranges, which can be particularly useful for network administrators, security professionals, and developers working with cloud infrastructure.
+cipr is a command-line interface (CLI) tool designed to simplify the process of retrieving IP ranges from AWS, Azure, Cloudflare, DigitalOcean, GitHub, Google Cloud, and iCloud Private Relay. It provides a quick and efficient way to access up-to-date IP ranges, which can be particularly useful for network administrators, security professionals, and developers working with cloud infrastructure.
 
 ## Installation
 
@@ -29,12 +29,31 @@ settings with `cipr configure`, or target one source key:
 cipr configure aws --endpoint https://example.com/aws-ranges.json
 cipr configure azure --local-file /path/to/azure-ranges.json --cache-ttl 0s
 cipr configure cloudflare_ipv4
+cipr configure gcp
 ```
 
 `--proxy` supplies an HTTP(S) proxy for all network requests. When it is not
 set, cipr uses the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
 environment variables. `--debug` writes source, cache, proxy, and HTTP
 diagnostics to stderr without changing IP-range output.
+
+## Google Cloud
+
+The `gcp` provider reads Google's [`cloud.json`](https://www.gstatic.com/ipranges/cloud.json)
+feed of [global and regional external IP ranges](https://cloud.google.com/vpc/docs/access-apis-external-ip)
+available to Google Cloud customers. These are not project-specific allocations
+or the broader ranges used by Google APIs and services.
+
+```bash
+cipr gcp --ipv4 --filter-scope us-central1
+cipr gcp --ipv6 --filter 'global,Google Cloud' --verbose-mode mini
+cipr gcp --list scopes
+```
+
+Scopes are Google Cloud region names or `global`. The feed's `service` field is
+currently `Google Cloud`; it does not identify individual products or APIs.
+Google updates the feed frequently. Use `--no-cache` when a fresh fetch is
+required instead of the default 24-hour cached copy.
 
 ## Contributing
 

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -23,7 +23,7 @@ var configureCmd = &cobra.Command{
 	Long: `Show or update cipr's managed configuration values.
 
 Source-specific settings use the keys written to cipr.toml, including aws,
-azure, cloudflare_ipv4, cloudflare_ipv6, digitalocean, github, and icloud.
+azure, cloudflare_ipv4, cloudflare_ipv6, digitalocean, gcp, github, and icloud.
 With no update flags, the effective managed configuration is displayed.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runConfigure,

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -72,5 +72,6 @@ func TestInlineAssignmentCommentIgnoresHashesInsideStrings(t *testing.T) {
 func TestConfiguredSourceKeysAreSorted(t *testing.T) {
 	keys := configuredSourceKeys()
 	assert.True(t, strings.Contains(strings.Join(keys, ","), "cloudflare_ipv4"))
+	assert.Contains(t, keys, "gcp")
 	assert.True(t, sort.StringsAreSorted(keys))
 }

--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/kaumnen/cipr/internal/gcp"
+	"github.com/kaumnen/cipr/internal/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var gcpCmd = &cobra.Command{
+	Use:   "gcp",
+	Short: "Get Google Cloud IP ranges.",
+	Long:  `Get Google Cloud IPv4 and IPv6 ranges with optional scope and service filtering.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		verbosity, err := resolveVerbosity(cmd)
+		if err != nil {
+			return err
+		}
+
+		ipType := resolveIPType(viper.GetBool("gcp_ipv4"), viper.GetBool("gcp_ipv6"))
+		filter := viper.GetString("gcp-filter")
+		filterScope := viper.GetString("gcp-filter-scope")
+		filterService := viper.GetString("gcp-filter-service")
+
+		if filter != "" && (filterScope != "" || filterService != "") {
+			return errors.New("--filter cannot be used with individual filter flags")
+		}
+
+		var gcpFilter string
+		if filter != "" {
+			gcpFilter = filter
+		} else {
+			gcpFilter = fmt.Sprintf("%s,%s", filterScope, filterService)
+		}
+
+		source := utils.ResolveSource("gcp")
+		if list := viper.GetString("gcp-list"); list != "" {
+			if !slices.Contains(gcpListDimensions, list) {
+				return fmt.Errorf("invalid --list value %q (valid: %s)", list, strings.Join(gcpListDimensions, ", "))
+			}
+			return gcp.GetIPRanges(cmd.Context(), gcp.Config{
+				Source:    source,
+				IPType:    "both",
+				Filter:    gcpFilter,
+				List:      list,
+				Verbosity: verbosity,
+			})
+		}
+
+		return gcp.GetIPRanges(cmd.Context(), gcp.Config{
+			Source: source, IPType: ipType, Filter: gcpFilter, Verbosity: verbosity,
+		})
+	},
+}
+
+var gcpListDimensions = []string{"scopes", "services"}
+
+func init() {
+	rootCmd.AddCommand(gcpCmd)
+
+	gcpCmd.Flags().Bool("ipv4", false, "Get only IPv4 ranges")
+	gcpCmd.Flags().Bool("ipv6", false, "Get only IPv6 ranges")
+	gcpCmd.Flags().String("filter", "", "Filter results. Syntax: scope,service")
+	gcpCmd.Flags().String("filter-scope", "", "Filter results by Google Cloud scope (for example, us-central1 or global)")
+	gcpCmd.Flags().String("filter-service", "", "Filter results by Google Cloud service")
+	gcpCmd.Flags().String("list", "", "List unique values for a dimension instead of IP ranges. Valid: scopes, services. Composes with --filter-* flags; ignores --ipv4/--ipv6.")
+
+	viper.BindPFlag("gcp_ipv4", gcpCmd.Flags().Lookup("ipv4"))
+	viper.BindPFlag("gcp_ipv6", gcpCmd.Flags().Lookup("ipv6"))
+	viper.BindPFlag("gcp-filter", gcpCmd.Flags().Lookup("filter"))
+	viper.BindPFlag("gcp-filter-scope", gcpCmd.Flags().Lookup("filter-scope"))
+	viper.BindPFlag("gcp-filter-service", gcpCmd.Flags().Lookup("filter-service"))
+	viper.BindPFlag("gcp-list", gcpCmd.Flags().Lookup("list"))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,8 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	Long: `cipr is a CLI tool for retrieving IP ranges from various cloud providers
-and services (AWS, Azure, Cloudflare, DigitalOcean, GitHub, iCloud Private Relay).
+and services (AWS, Azure, Cloudflare, DigitalOcean, GitHub, Google Cloud,
+iCloud Private Relay).
 
 It provides a quick and efficient way to access up-to-date IP ranges, useful
 for network administrators, security professionals, and developers working

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -59,6 +59,7 @@ func TestEnsureConfigFileCreatesDefaultsForConfigure(t *testing.T) {
 	assert.Contains(t, text, `proxy = ""`)
 	assert.Contains(t, text, "debug = false")
 	assert.Contains(t, text, "cloudflare_ipv4_endpoint")
+	assert.Contains(t, text, "gcp_endpoint")
 }
 
 func TestEnsureConfigFileLeavesMissingCustomConfigForNormalCommands(t *testing.T) {

--- a/internal/gcp/logic.go
+++ b/internal/gcp/logic.go
@@ -1,0 +1,174 @@
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kaumnen/cipr/internal/utils"
+)
+
+type sourcePrefix struct {
+	IPv4Prefix string `json:"ipv4Prefix"`
+	IPv6Prefix string `json:"ipv6Prefix"`
+	Service    string `json:"service"`
+	Scope      string `json:"scope"`
+}
+
+type IPsData struct {
+	SyncToken    string         `json:"syncToken"`
+	CreationTime string         `json:"creationTime"`
+	Prefixes     []sourcePrefix `json:"prefixes"`
+}
+
+type Prefix struct {
+	Address string
+	Scope   string
+	Service string
+}
+
+type Config struct {
+	Source    string
+	IPType    string
+	Filter    string
+	List      string
+	Verbosity string
+}
+
+func GetIPRanges(ctx context.Context, config Config) error {
+	rawData, err := utils.GetRawData(ctx, config.Source)
+	if err != nil {
+		return err
+	}
+
+	ipType := config.IPType
+	if config.List != "" {
+		ipType = "both"
+	}
+	prefixes, err := filtrateIPRanges(rawData, ipType, separateFilters(config.Filter))
+	if err != nil {
+		return err
+	}
+	if config.List != "" {
+		return printListedValues(prefixes, config.List)
+	}
+	printIPRanges(prefixes, config.Verbosity)
+	return nil
+}
+
+func separateFilters(filterFlagValues string) []string {
+	values := strings.Split(filterFlagValues, ",")
+	filters := make([]string, 0, 2)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			value = "*"
+		}
+		filters = append(filters, value)
+	}
+	for len(filters) < 2 {
+		filters = append(filters, "*")
+	}
+	return filters[:2]
+}
+
+func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]Prefix, error) {
+	var data IPsData
+	if err := json.Unmarshal([]byte(rawData), &data); err != nil {
+		return nil, fmt.Errorf("parse gcp cloud ip-ranges json: %w", err)
+	}
+	if len(data.Prefixes) == 0 {
+		return nil, fmt.Errorf("validate gcp cloud ip-ranges json: no IP ranges found")
+	}
+
+	var result []Prefix
+	for i, source := range data.Prefixes {
+		if source.IPv4Prefix == "" && source.IPv6Prefix == "" {
+			return nil, fmt.Errorf("validate gcp prefix %d: missing ipv4Prefix or ipv6Prefix", i+1)
+		}
+		if source.IPv4Prefix != "" && source.IPv6Prefix != "" {
+			return nil, fmt.Errorf("validate gcp prefix %d: both ipv4Prefix and ipv6Prefix are set", i+1)
+		}
+
+		address := source.IPv4Prefix
+		family := "IPv4"
+		if address == "" {
+			address = source.IPv6Prefix
+			family = "IPv6"
+		}
+		if !utils.IsCIDR(address) {
+			return nil, fmt.Errorf("validate gcp %s prefix %d: %q is not a valid CIDR", family, i+1, address)
+		}
+		wrongFamily := (family == "IPv4" && !utils.IsIPv4(address)) ||
+			(family == "IPv6" && !utils.IsIPv6(address))
+		if wrongFamily {
+			return nil, fmt.Errorf("validate gcp %s prefix %d: %q has the wrong address family", family, i+1, address)
+		}
+		if !matchesFilter(source, filterSlice) || !ipVersionMatches(address, ipType) {
+			continue
+		}
+		result = append(result, Prefix{Address: address, Scope: source.Scope, Service: source.Service})
+	}
+	return result, nil
+}
+
+func matchesFilter(prefix sourcePrefix, filterSlice []string) bool {
+	return (filterSlice[0] == "*" || strings.EqualFold(prefix.Scope, filterSlice[0])) &&
+		(filterSlice[1] == "*" || strings.EqualFold(prefix.Service, filterSlice[1]))
+}
+
+func ipVersionMatches(address, ipType string) bool {
+	switch ipType {
+	case "ipv4":
+		return utils.IsIPv4(address)
+	case "ipv6":
+		return utils.IsIPv6(address)
+	default:
+		return true
+	}
+}
+
+func printListedValues(prefixes []Prefix, dimension string) error {
+	values := make([]string, 0, len(prefixes))
+	switch dimension {
+	case "scopes":
+		for _, prefix := range prefixes {
+			values = append(values, prefix.Scope)
+		}
+	case "services":
+		for _, prefix := range prefixes {
+			values = append(values, prefix.Service)
+		}
+	default:
+		return fmt.Errorf("unknown list dimension %q (valid: scopes, services)", dimension)
+	}
+
+	values = utils.DedupeSorted(values)
+	if len(values) == 0 {
+		fmt.Println("No values to display.")
+		return nil
+	}
+	for _, value := range values {
+		fmt.Println(value)
+	}
+	return nil
+}
+
+func printIPRanges(prefixes []Prefix, verbosity string) {
+	if len(prefixes) == 0 {
+		fmt.Println("No IP ranges to display.")
+		return
+	}
+
+	for _, prefix := range prefixes {
+		switch verbosity {
+		case "mini":
+			fmt.Printf("%s,%s,%s\n", prefix.Address, prefix.Scope, prefix.Service)
+		case "full":
+			fmt.Printf("IP Prefix: %s, Scope: %s, Service: %s\n", prefix.Address, prefix.Scope, prefix.Service)
+		default:
+			fmt.Println(prefix.Address)
+		}
+	}
+}

--- a/internal/gcp/logic_test.go
+++ b/internal/gcp/logic_test.go
@@ -1,0 +1,289 @@
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadFixture(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "gcp_cloud_sample.json"))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	return buf.String()
+}
+
+func TestSeparateFilters(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty", want: []string{"*", "*"}},
+		{name: "scope only", input: "global", want: []string{"global", "*"}},
+		{name: "service only", input: ",Google Cloud", want: []string{"*", "Google Cloud"}},
+		{name: "both", input: "asia-east1,Google Cloud", want: []string{"asia-east1", "Google Cloud"}},
+		{name: "trims surrounding whitespace", input: " asia-east1 , Google Cloud ", want: []string{"asia-east1", "Google Cloud"}},
+		{name: "truncates extra values", input: "global,Google Cloud,ignored", want: []string{"global", "Google Cloud"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, separateFilters(tt.input))
+		})
+	}
+}
+
+func TestFiltrateIPRanges(t *testing.T) {
+	rawData := loadFixture(t)
+	tests := []struct {
+		name   string
+		ipType string
+		filter string
+		want   []Prefix
+	}{
+		{
+			name:   "IPv4",
+			ipType: "ipv4",
+			want: []Prefix{
+				{Address: "34.1.208.0/20", Scope: "africa-south1", Service: "Google Cloud"},
+				{Address: "34.80.0.0/15", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "8.228.224.0/20", Scope: "global", Service: "Google Cloud"},
+			},
+		},
+		{
+			name:   "IPv6",
+			ipType: "ipv6",
+			want: []Prefix{
+				{Address: "2600:1900:8000::/44", Scope: "africa-south1", Service: "Google Cloud"},
+				{Address: "2600:1900:4030::/44", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "2600:1901::/48", Scope: "global", Service: "Google Cloud"},
+			},
+		},
+		{
+			name:   "both families preserve source order",
+			ipType: "both",
+			want: []Prefix{
+				{Address: "34.1.208.0/20", Scope: "africa-south1", Service: "Google Cloud"},
+				{Address: "2600:1900:8000::/44", Scope: "africa-south1", Service: "Google Cloud"},
+				{Address: "34.80.0.0/15", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "2600:1900:4030::/44", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "8.228.224.0/20", Scope: "global", Service: "Google Cloud"},
+				{Address: "2600:1901::/48", Scope: "global", Service: "Google Cloud"},
+			},
+		},
+		{
+			name:   "scope filter is case-insensitive",
+			ipType: "ipv4",
+			filter: "ASIA-EAST1,",
+			want:   []Prefix{{Address: "34.80.0.0/15", Scope: "asia-east1", Service: "Google Cloud"}},
+		},
+		{
+			name:   "service filter preserves embedded space",
+			ipType: "ipv6",
+			filter: ",google cloud",
+			want: []Prefix{
+				{Address: "2600:1900:8000::/44", Scope: "africa-south1", Service: "Google Cloud"},
+				{Address: "2600:1900:4030::/44", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "2600:1901::/48", Scope: "global", Service: "Google Cloud"},
+			},
+		},
+		{
+			name:   "combined filter",
+			ipType: "ipv6",
+			filter: "GLOBAL,GOOGLE CLOUD",
+			want:   []Prefix{{Address: "2600:1901::/48", Scope: "global", Service: "Google Cloud"}},
+		},
+		{name: "no matches", ipType: "both", filter: "moon,*", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filtrateIPRanges(rawData, tt.ipType, separateFilters(tt.filter))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFiltrateIPRangesValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "malformed JSON", raw: `{`, want: "parse gcp cloud ip-ranges json"},
+		{name: "empty payload", raw: `{}`, want: "no IP ranges found"},
+		{name: "empty prefixes", raw: `{"prefixes":[]}`, want: "no IP ranges found"},
+		{name: "missing address", raw: `{"prefixes":[{"service":"Google Cloud","scope":"global"}]}`, want: "missing ipv4Prefix or ipv6Prefix"},
+		{name: "both addresses", raw: `{"prefixes":[{"ipv4Prefix":"1.1.1.0/24","ipv6Prefix":"2001:db8::/32"}]}`, want: "both ipv4Prefix and ipv6Prefix"},
+		{name: "invalid CIDR", raw: `{"prefixes":[{"ipv4Prefix":"not-a-cidr"}]}`, want: `IPv4 prefix 1: "not-a-cidr"`},
+		{name: "IPv4 field has IPv6", raw: `{"prefixes":[{"ipv4Prefix":"2001:db8::/32"}]}`, want: "wrong address family"},
+		{name: "IPv6 field has IPv4", raw: `{"prefixes":[{"ipv6Prefix":"192.0.2.0/24"}]}`, want: "wrong address family"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := filtrateIPRanges(tt.raw, "both", separateFilters(""))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestFiltrateIPRangesValidatesExcludedEntries(t *testing.T) {
+	rawData := `{"prefixes":[
+		{"ipv4Prefix":"192.0.2.0/24","service":"Google Cloud","scope":"global"},
+		{"ipv6Prefix":"invalid","service":"Google Cloud","scope":"elsewhere"}
+	]}`
+	_, err := filtrateIPRanges(rawData, "ipv4", separateFilters("global,"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "validate gcp IPv6 prefix 2")
+}
+
+func TestFiltrateIPRangesFiltersService(t *testing.T) {
+	rawData := `{"prefixes":[
+		{"ipv4Prefix":"192.0.2.0/24","service":"Google Cloud","scope":"global"},
+		{"ipv4Prefix":"198.51.100.0/24","service":"Future Service","scope":"global"}
+	]}`
+	got, err := filtrateIPRanges(rawData, "ipv4", separateFilters(",google cloud"))
+	require.NoError(t, err)
+	assert.Equal(t, []Prefix{
+		{Address: "192.0.2.0/24", Scope: "global", Service: "Google Cloud"},
+	}, got)
+}
+
+func TestPrintIPRanges(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefixes  []Prefix
+		verbosity string
+		want      string
+	}{
+		{name: "empty", verbosity: "none", want: "No IP ranges to display.\n"},
+		{
+			name: "none",
+			prefixes: []Prefix{
+				{Address: "34.80.0.0/15", Scope: "asia-east1", Service: "Google Cloud"},
+				{Address: "2600:1900:4030::/44", Scope: "asia-east1", Service: "Google Cloud"},
+			},
+			verbosity: "none",
+			want:      "34.80.0.0/15\n2600:1900:4030::/44\n",
+		},
+		{
+			name:      "mini",
+			prefixes:  []Prefix{{Address: "8.228.224.0/20", Scope: "global", Service: "Google Cloud"}},
+			verbosity: "mini",
+			want:      "8.228.224.0/20,global,Google Cloud\n",
+		},
+		{
+			name:      "full",
+			prefixes:  []Prefix{{Address: "2600:1901::/48", Scope: "global", Service: "Google Cloud"}},
+			verbosity: "full",
+			want:      "IP Prefix: 2600:1901::/48, Scope: global, Service: Google Cloud\n",
+		},
+		{
+			name:      "unknown verbosity falls back to CIDR only",
+			prefixes:  []Prefix{{Address: "34.1.208.0/20", Scope: "africa-south1", Service: "Google Cloud"}},
+			verbosity: "unknown",
+			want:      "34.1.208.0/20\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() { printIPRanges(tt.prefixes, tt.verbosity) })
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestPrintListedValues(t *testing.T) {
+	prefixes := []Prefix{
+		{Address: "34.80.0.0/15", Scope: "asia-east1", Service: "Google Cloud"},
+		{Address: "2600:1900:4030::/44", Scope: "asia-east1", Service: "Google Cloud"},
+		{Address: "8.228.224.0/20", Scope: "global", Service: "Google Cloud"},
+		{Address: "192.0.2.0/24", Scope: "", Service: ""},
+	}
+
+	t.Run("scopes are sorted deduplicated and non-empty", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			require.NoError(t, printListedValues(prefixes, "scopes"))
+		})
+		assert.Equal(t, "asia-east1\nglobal\n", out)
+	})
+	t.Run("services are sorted deduplicated and non-empty", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			require.NoError(t, printListedValues(prefixes, "services"))
+		})
+		assert.Equal(t, "Google Cloud\n", out)
+	})
+	t.Run("empty input", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			require.NoError(t, printListedValues(nil, "scopes"))
+		})
+		assert.Equal(t, "No values to display.\n", out)
+	})
+	t.Run("unknown dimension", func(t *testing.T) {
+		err := printListedValues(prefixes, "regions")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "valid: scopes, services")
+	})
+}
+
+func TestGetIPRanges(t *testing.T) {
+	config := Config{
+		Source:    filepath.Join("..", "testdata", "gcp_cloud_sample.json"),
+		IPType:    "ipv4",
+		Filter:    "global,Google Cloud",
+		Verbosity: "mini",
+	}
+	out := captureStdout(t, func() {
+		require.NoError(t, GetIPRanges(context.Background(), config))
+	})
+	assert.Equal(t, "8.228.224.0/20,global,Google Cloud\n", out)
+}
+
+func TestGetIPRangesListComposesWithFilterAndIgnoresIPType(t *testing.T) {
+	config := Config{
+		Source: filepath.Join("..", "testdata", "gcp_cloud_sample.json"),
+		IPType: "ipv4",
+		Filter: ",Google Cloud",
+		List:   "scopes",
+	}
+	out := captureStdout(t, func() {
+		require.NoError(t, GetIPRanges(context.Background(), config))
+	})
+	assert.Equal(t, "africa-south1\nasia-east1\nglobal\n", out)
+}
+
+func TestGetIPRangesPropagatesSourceError(t *testing.T) {
+	err := GetIPRanges(context.Background(), Config{Source: filepath.Join(t.TempDir(), "missing.json")})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "read")
+}

--- a/internal/testdata/gcp_cloud_sample.json
+++ b/internal/testdata/gcp_cloud_sample.json
@@ -1,0 +1,36 @@
+{
+  "syncToken": "1783670691420",
+  "creationTime": "2026-07-10T01:04:51.420656",
+  "prefixes": [
+    {
+      "ipv4Prefix": "34.1.208.0/20",
+      "service": "Google Cloud",
+      "scope": "africa-south1"
+    },
+    {
+      "ipv6Prefix": "2600:1900:8000::/44",
+      "service": "Google Cloud",
+      "scope": "africa-south1"
+    },
+    {
+      "ipv4Prefix": "34.80.0.0/15",
+      "service": "Google Cloud",
+      "scope": "asia-east1"
+    },
+    {
+      "ipv6Prefix": "2600:1900:4030::/44",
+      "service": "Google Cloud",
+      "scope": "asia-east1"
+    },
+    {
+      "ipv4Prefix": "8.228.224.0/20",
+      "service": "Google Cloud",
+      "scope": "global"
+    },
+    {
+      "ipv6Prefix": "2600:1901::/48",
+      "service": "Google Cloud",
+      "scope": "global"
+    }
+  ]
+}

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -17,6 +17,7 @@ var DefaultEndpoints = map[string]string{
 	"cloudflare_ipv6": "https://www.cloudflare.com/ips-v6/",
 	"icloud":          "https://mask-api.icloud.com/egress-ip-ranges.csv",
 	"digitalocean":    "https://digitalocean.com/geo/google.csv",
+	"gcp":             "https://www.gstatic.com/ipranges/cloud.json",
 	"github":          "https://api.github.com/meta",
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -37,6 +37,10 @@ run_and_expect aws "44.192.140.112/28" aws \
     --filter-network-border-group us-east-1
 run_and_expect azure "13.66.143.220/30" azure \
     --source "$ROOT_DIR/internal/testdata/azure_servicetags_sample.json" --ipv4
+run_and_expect gcp "34.80.0.0/15" gcp \
+    --source "$ROOT_DIR/internal/testdata/gcp_cloud_sample.json" --ipv4 \
+    --filter-scope asia-east1 --filter-service "Google Cloud"
+test "$(wc -l < "$WORK_DIR/gcp.out")" -eq 1
 run_and_expect cloudflare-v4 "173.245.48.0/20" cloudflare \
     --source "$ROOT_DIR/internal/testdata/cloudflare_ipv4.txt" --ipv4
 run_and_expect cloudflare-v6 "2400:cb00::/32" cloudflare \


### PR DESCRIPTION
## summary

- add a gcp provider backed by google cloud cloud.json ranges
- support ipv4 and ipv6 filtering by scope and service plus list output
- add configuration docs fixture tests and smoke coverage

## checks

- go test ./...
- go build ./...
- ./scripts/smoke-test.sh
- golangci-lint run