### PR TITLE
feat: support multiple provider filter values

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -28,19 +28,14 @@ var awsCmd = &cobra.Command{
 		ipType := resolveIPType(ipv4, ipv6)
 
 		filter := viper.GetString("aws-filter")
-		filterRegion := viper.GetString("aws-filter-region")
-		filterService := viper.GetString("aws-filter-service")
-		filterNetworkBorderGroup := viper.GetString("aws-filter-network-border-group")
-
-		if filter != "" && (filterRegion != "" || filterService != "" || filterNetworkBorderGroup != "") {
-			return errors.New("--filter cannot be used with individual filter flags")
+		filters := aws.Filters{
+			Region:             viper.GetStringSlice("aws-filter-region"),
+			Service:            viper.GetStringSlice("aws-filter-service"),
+			NetworkBorderGroup: viper.GetStringSlice("aws-filter-network-border-group"),
 		}
 
-		var awsFilter string
-		if filter != "" {
-			awsFilter = filter
-		} else {
-			awsFilter = fmt.Sprintf("%s,%s,%s", filterRegion, filterService, filterNetworkBorderGroup)
+		if filter != "" && (len(filters.Region) > 0 || len(filters.Service) > 0 || len(filters.NetworkBorderGroup) > 0) {
+			return errors.New("--filter cannot be used with individual filter flags")
 		}
 
 		source := utils.ResolveSource("aws")
@@ -52,14 +47,15 @@ var awsCmd = &cobra.Command{
 			return aws.GetIPRanges(cmd.Context(), aws.Config{
 				Source:    source,
 				IPType:    "",
-				Filter:    awsFilter,
+				Filter:    filter,
+				Filters:   filters,
 				List:      list,
 				Verbosity: verbosity,
 			})
 		}
 
 		return aws.GetIPRanges(cmd.Context(), aws.Config{
-			Source: source, IPType: ipType, Filter: awsFilter, Verbosity: verbosity,
+			Source: source, IPType: ipType, Filter: filter, Filters: filters, Verbosity: verbosity,
 		})
 	},
 }
@@ -73,9 +69,9 @@ func init() {
 	awsCmd.Flags().Bool("ipv6", false, "Get only IPv6 ranges")
 	awsCmd.Flags().String("filter", "", "Filter results. Syntax: region,service,network-border-group")
 
-	awsCmd.Flags().String("filter-region", "", "Filter results by AWS region")
-	awsCmd.Flags().String("filter-service", "", "Filter results by AWS service")
-	awsCmd.Flags().String("filter-network-border-group", "", "Filter results by AWS network border group")
+	awsCmd.Flags().StringSlice("filter-region", []string{}, "Filter results by AWS region (comma-separated)")
+	awsCmd.Flags().StringSlice("filter-service", []string{}, "Filter results by AWS service (comma-separated)")
+	awsCmd.Flags().StringSlice("filter-network-border-group", []string{}, "Filter results by AWS network border group (comma-separated)")
 	awsCmd.Flags().String("list", "", "List unique values for a dimension instead of IP ranges. Valid: regions, services, network-border-groups. Composes with --filter-* flags; ignores --ipv4/--ipv6.")
 
 	viper.BindPFlag("aws_ipv4", awsCmd.Flags().Lookup("ipv4"))

--- a/cmd/azure.go
+++ b/cmd/azure.go
@@ -28,18 +28,13 @@ var azureCmd = &cobra.Command{
 		ipType := resolveIPType(ipv4, ipv6)
 
 		filter := viper.GetString("azure-filter")
-		filterRegion := viper.GetString("azure-filter-region")
-		filterService := viper.GetString("azure-filter-service")
-
-		if filter != "" && (filterRegion != "" || filterService != "") {
-			return errors.New("--filter cannot be used with individual filter flags")
+		filters := azure.Filters{
+			Region:  viper.GetStringSlice("azure-filter-region"),
+			Service: viper.GetStringSlice("azure-filter-service"),
 		}
 
-		var azureFilter string
-		if filter != "" {
-			azureFilter = filter
-		} else {
-			azureFilter = fmt.Sprintf("%s,%s", filterRegion, filterService)
+		if filter != "" && (len(filters.Region) > 0 || len(filters.Service) > 0) {
+			return errors.New("--filter cannot be used with individual filter flags")
 		}
 
 		source := utils.ResolveSource("azure")
@@ -51,14 +46,15 @@ var azureCmd = &cobra.Command{
 			return azure.GetIPRanges(cmd.Context(), azure.Config{
 				Source:    source,
 				IPType:    "",
-				Filter:    azureFilter,
+				Filter:    filter,
+				Filters:   filters,
 				List:      list,
 				Verbosity: verbosity,
 			})
 		}
 
 		return azure.GetIPRanges(cmd.Context(), azure.Config{
-			Source: source, IPType: ipType, Filter: azureFilter, Verbosity: verbosity,
+			Source: source, IPType: ipType, Filter: filter, Filters: filters, Verbosity: verbosity,
 		})
 	},
 }
@@ -72,8 +68,8 @@ func init() {
 	azureCmd.Flags().Bool("ipv6", false, "Get only IPv6 ranges")
 	azureCmd.Flags().String("filter", "", "Filter results. Syntax: region,service")
 
-	azureCmd.Flags().String("filter-region", "", "Filter results by Azure region (e.g. westeurope)")
-	azureCmd.Flags().String("filter-service", "", "Filter results by Azure system service (e.g. AzureStorage)")
+	azureCmd.Flags().StringSlice("filter-region", []string{}, "Filter results by Azure region (comma-separated, e.g. westeurope,eastus)")
+	azureCmd.Flags().StringSlice("filter-service", []string{}, "Filter results by Azure system service (comma-separated, e.g. AzureStorage,AzureKeyVault)")
 	azureCmd.Flags().String("list", "", "List unique values for a dimension instead of IP ranges. Valid: regions, services. Composes with --filter-* flags; ignores --ipv4/--ipv6.")
 
 	viper.BindPFlag("azure_ipv4", azureCmd.Flags().Lookup("ipv4"))

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -34,7 +34,7 @@ var githubCmd = &cobra.Command{
 			ipType = ""
 		}
 
-		filterService := viper.GetString("github-filter-service")
+		filterServices := viper.GetStringSlice("github-filter-service")
 		source := utils.ResolveSource("github")
 
 		if list := viper.GetString("github-list"); list != "" {
@@ -42,19 +42,19 @@ var githubCmd = &cobra.Command{
 				return fmt.Errorf("invalid --list value %q (valid: %s)", list, strings.Join(githubListDimensions, ", "))
 			}
 			return github.GetIPRanges(cmd.Context(), github.Config{
-				Source:        source,
-				IPType:        "",
-				FilterService: filterService,
-				List:          list,
-				Verbosity:     verbosity,
+				Source:         source,
+				IPType:         "",
+				FilterServices: filterServices,
+				List:           list,
+				Verbosity:      verbosity,
 			})
 		}
 
 		return github.GetIPRanges(cmd.Context(), github.Config{
-			Source:        source,
-			IPType:        ipType,
-			FilterService: filterService,
-			Verbosity:     verbosity,
+			Source:         source,
+			IPType:         ipType,
+			FilterServices: filterServices,
+			Verbosity:      verbosity,
 		})
 	},
 }
@@ -66,7 +66,7 @@ func init() {
 
 	githubCmd.Flags().Bool("ipv4", false, "Get only IPv4 ranges")
 	githubCmd.Flags().Bool("ipv6", false, "Get only IPv6 ranges")
-	githubCmd.Flags().String("filter-service", "", "Filter results by GitHub service (e.g. actions, web, api, git, hooks, pages, packages, importer, github_enterprise_importer)")
+	githubCmd.Flags().StringSlice("filter-service", []string{}, "Filter results by GitHub service (comma-separated; e.g. actions, web, api, git, hooks, pages, packages, importer, github_enterprise_importer)")
 	githubCmd.Flags().String("list", "", "List unique values for a dimension instead of IP ranges. Valid: services. Composes with --filter-service; ignores --ipv4/--ipv6.")
 
 	viper.BindPFlag("github_ipv4", githubCmd.Flags().Lookup("ipv4"))

--- a/internal/aws/logic.go
+++ b/internal/aws/logic.go
@@ -51,8 +51,15 @@ type Config struct {
 	Source    string
 	IPType    string
 	Filter    string
+	Filters   Filters
 	List      string
 	Verbosity string
+}
+
+type Filters struct {
+	Region             []string
+	Service            []string
+	NetworkBorderGroup []string
 }
 
 func GetIPRanges(ctx context.Context, config Config) error {
@@ -61,8 +68,11 @@ func GetIPRanges(ctx context.Context, config Config) error {
 		return err
 	}
 
-	filterSlice := separateFilters(config.Filter)
-	readyIPs, err := filtrateIPRanges(rawData, config.IPType, filterSlice)
+	filters := config.Filters
+	if config.Filter != "" {
+		filters = filtersFromComposite(config.Filter)
+	}
+	readyIPs, err := filtrateIPRanges(rawData, config.IPType, filters)
 	if err != nil {
 		return err
 	}
@@ -126,7 +136,23 @@ func separateFilters(filterFlagValues string) []string {
 	return filterSlice
 }
 
-func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]IPPrefix, error) {
+func filtersFromComposite(filter string) Filters {
+	parts := separateFilters(filter)
+	return Filters{
+		Region:             wildcardToEmpty(parts[0]),
+		Service:            wildcardToEmpty(parts[1]),
+		NetworkBorderGroup: wildcardToEmpty(parts[2]),
+	}
+}
+
+func wildcardToEmpty(value string) []string {
+	if value == "*" {
+		return nil
+	}
+	return []string{value}
+}
+
+func filtrateIPRanges(rawData, ipType string, filters Filters) ([]IPPrefix, error) {
 	var data IPsData
 	if err := json.Unmarshal([]byte(rawData), &data); err != nil {
 		return nil, fmt.Errorf("parse aws ip-ranges json: %w", err)
@@ -159,17 +185,17 @@ func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]IPPrefix,
 
 	var result []IPPrefix
 	for _, prefix := range prefixes {
-		if matchesFilter(prefix, filterSlice) {
+		if matchesFilter(prefix, filters) {
 			result = append(result, prefix)
 		}
 	}
 	return result, nil
 }
 
-func matchesFilter(prefix IPPrefix, filterSlice []string) bool {
-	return (filterSlice[0] == "*" || strings.EqualFold(prefix.GetRegion(), filterSlice[0])) &&
-		(filterSlice[1] == "*" || strings.EqualFold(prefix.GetService(), filterSlice[1])) &&
-		(filterSlice[2] == "*" || strings.EqualFold(prefix.GetNetworkBorderGroup(), filterSlice[2]))
+func matchesFilter(prefix IPPrefix, filters Filters) bool {
+	return (len(filters.Region) == 0 || utils.ContainsIgnoreCase(filters.Region, prefix.GetRegion())) &&
+		(len(filters.Service) == 0 || utils.ContainsIgnoreCase(filters.Service, prefix.GetService())) &&
+		(len(filters.NetworkBorderGroup) == 0 || utils.ContainsIgnoreCase(filters.NetworkBorderGroup, prefix.GetNetworkBorderGroup()))
 }
 
 func printIPRanges(ipRanges []IPPrefix, verbosity string) {

--- a/internal/aws/logic_test.go
+++ b/internal/aws/logic_test.go
@@ -48,15 +48,15 @@ func TestSeparateFilters(t *testing.T) {
 
 func TestFiltrateIPRanges(t *testing.T) {
 	testCases := []struct {
-		name        string
-		ipType      string
-		filterSlice []string
-		expected    []IPPrefix
+		name     string
+		ipType   string
+		filters  Filters
+		expected []IPPrefix
 	}{
 		{
-			name:        "ipv4 - filters: us-east-1 region, EBS service",
-			ipType:      "ipv4",
-			filterSlice: []string{"us-east-1", "EBS", "*"},
+			name:    "ipv4 - filters: us-east-1 region, EBS service",
+			ipType:  "ipv4",
+			filters: Filters{Region: []string{"us-east-1"}, Service: []string{"EBS"}},
 			expected: []IPPrefix{
 				IPv4Prefix{IPAddress: "44.192.140.112/28", Region: "us-east-1", Service: "EBS", NetworkBorderGroup: "us-east-1"},
 				IPv4Prefix{IPAddress: "44.192.140.128/29", Region: "us-east-1", Service: "EBS", NetworkBorderGroup: "us-east-1"},
@@ -65,9 +65,13 @@ func TestFiltrateIPRanges(t *testing.T) {
 			},
 		},
 		{
-			name:        "ipv6 - filters: eu-central-1 region, S3 service, eu-central-1 network border group",
-			ipType:      "ipv6",
-			filterSlice: []string{"eu-central-1", "S3", "eu-central-1"},
+			name:   "ipv6 - filters: eu-central-1 region, S3 service, eu-central-1 network border group",
+			ipType: "ipv6",
+			filters: Filters{
+				Region:             []string{"eu-central-1"},
+				Service:            []string{"S3"},
+				NetworkBorderGroup: []string{"eu-central-1"},
+			},
 			expected: []IPPrefix{
 				IPv6Prefix{IPv6Address: "2a05:d070:4000::/40", Region: "eu-central-1", Service: "S3", NetworkBorderGroup: "eu-central-1"},
 				IPv6Prefix{IPv6Address: "2a05:d079:4000::/40", Region: "eu-central-1", Service: "S3", NetworkBorderGroup: "eu-central-1"},
@@ -83,7 +87,7 @@ func TestFiltrateIPRanges(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rawData := mockGetReq()
 
-			result, err := filtrateIPRanges(rawData, tc.ipType, tc.filterSlice)
+			result, err := filtrateIPRanges(rawData, tc.ipType, tc.filters)
 			assert.NoError(t, err)
 
 			assert.Equal(t, len(tc.expected), len(result), "Test case '%s' failed: expected %d items, got %d",
@@ -111,11 +115,25 @@ func TestFiltrateIPRanges_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := filtrateIPRanges(tt.raw, "ipv4", []string{"*", "*", "*"})
+			_, err := filtrateIPRanges(tt.raw, "ipv4", Filters{})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.want)
 		})
 	}
+}
+
+func TestMatchesFilterMultipleValues(t *testing.T) {
+	prefix := IPv4Prefix{Region: "eu-central-1", Service: "S3", NetworkBorderGroup: "eu-central-1"}
+
+	assert.True(t, matchesFilter(prefix, Filters{
+		Region:             []string{"eu-west-1", "EU-CENTRAL-1"},
+		Service:            []string{"EC2", "s3"},
+		NetworkBorderGroup: []string{"eu-central-1", "global"},
+	}))
+	assert.False(t, matchesFilter(prefix, Filters{
+		Region:  []string{"eu-west-1", "eu-central-1"},
+		Service: []string{"EC2", "DYNAMODB"},
+	}))
 }
 
 func TestPrintIPRanges(t *testing.T) {

--- a/internal/azure/logic.go
+++ b/internal/azure/logic.go
@@ -25,8 +25,14 @@ type Config struct {
 	Source    string
 	IPType    string
 	Filter    string
+	Filters   Filters
 	List      string
 	Verbosity string
+}
+
+type Filters struct {
+	Region  []string
+	Service []string
 }
 
 type rawData struct {
@@ -79,8 +85,11 @@ func GetIPRanges(ctx context.Context, config Config) error {
 		return err
 	}
 
-	filterSlice := separateFilters(config.Filter)
-	prefixes, err := filtrateIPRanges(raw, config.IPType, filterSlice)
+	filters := config.Filters
+	if config.Filter != "" {
+		filters = filtersFromComposite(config.Filter)
+	}
+	prefixes, err := filtrateIPRanges(raw, config.IPType, filters)
 	if err != nil {
 		return err
 	}
@@ -223,7 +232,22 @@ func separateFilters(filterFlagValues string) []string {
 	return filterSlice
 }
 
-func filtrateIPRanges(raw, ipType string, filterSlice []string) ([]Prefix, error) {
+func filtersFromComposite(filter string) Filters {
+	parts := separateFilters(filter)
+	return Filters{
+		Region:  wildcardToEmpty(parts[0]),
+		Service: wildcardToEmpty(parts[1]),
+	}
+}
+
+func wildcardToEmpty(value string) []string {
+	if value == "*" {
+		return nil
+	}
+	return []string{value}
+}
+
+func filtrateIPRanges(raw, ipType string, filters Filters) ([]Prefix, error) {
 	var data rawData
 	if err := json.Unmarshal([]byte(raw), &data); err != nil {
 		return nil, fmt.Errorf("parse azure service-tags json: %w", err)
@@ -244,7 +268,7 @@ func filtrateIPRanges(raw, ipType string, filterSlice []string) ([]Prefix, error
 
 	var result []Prefix
 	for _, v := range data.Values {
-		if !matchesFilter(v.Properties, filterSlice) {
+		if !matchesFilter(v.Properties, filters) {
 			continue
 		}
 		for _, addr := range v.Properties.AddressPrefixes {
@@ -261,9 +285,9 @@ func filtrateIPRanges(raw, ipType string, filterSlice []string) ([]Prefix, error
 	return result, nil
 }
 
-func matchesFilter(p properties, filterSlice []string) bool {
-	return (filterSlice[0] == "*" || strings.EqualFold(p.Region, filterSlice[0])) &&
-		(filterSlice[1] == "*" || strings.EqualFold(p.SystemService, filterSlice[1]))
+func matchesFilter(p properties, filters Filters) bool {
+	return (len(filters.Region) == 0 || utils.ContainsIgnoreCase(filters.Region, p.Region)) &&
+		(len(filters.Service) == 0 || utils.ContainsIgnoreCase(filters.Service, p.SystemService))
 }
 
 func ipVersionMatches(addr, ipType string) bool {

--- a/internal/azure/logic_test.go
+++ b/internal/azure/logic_test.go
@@ -50,13 +50,13 @@ func TestFiltrateIPRanges(t *testing.T) {
 	cases := []struct {
 		name     string
 		ipType   string
-		filter   []string
+		filters  Filters
 		expected []Prefix
 	}{
 		{
-			name:   "ipv4 no filter",
-			ipType: "ipv4",
-			filter: []string{"*", "*"},
+			name:    "ipv4 no filter",
+			ipType:  "ipv4",
+			filters: Filters{},
 			expected: []Prefix{
 				{Address: "13.66.143.220/30", Region: "", Service: "ActionGroup"},
 				{Address: "20.50.32.0/19", Region: "westeurope", Service: "AzureStorage"},
@@ -65,9 +65,9 @@ func TestFiltrateIPRanges(t *testing.T) {
 			},
 		},
 		{
-			name:   "ipv6 no filter",
-			ipType: "ipv6",
-			filter: []string{"*", "*"},
+			name:    "ipv6 no filter",
+			ipType:  "ipv6",
+			filters: Filters{},
 			expected: []Prefix{
 				{Address: "2603:1000:4::10c/126", Region: "", Service: "ActionGroup"},
 				{Address: "2603:1020:206::/48", Region: "westeurope", Service: "AzureStorage"},
@@ -76,38 +76,38 @@ func TestFiltrateIPRanges(t *testing.T) {
 		{
 			name:     "filter by region",
 			ipType:   "ipv4",
-			filter:   []string{"westeurope", "*"},
+			filters:  Filters{Region: []string{"westeurope"}},
 			expected: []Prefix{{Address: "20.50.32.0/19", Region: "westeurope", Service: "AzureStorage"}},
 		},
 		{
 			name:     "filter by service",
 			ipType:   "ipv4",
-			filter:   []string{"*", "ActionGroup"},
+			filters:  Filters{Service: []string{"ActionGroup"}},
 			expected: []Prefix{{Address: "13.66.143.220/30", Region: "", Service: "ActionGroup"}},
 		},
 		{
 			name:     "filter by region and service combined",
 			ipType:   "ipv6",
-			filter:   []string{"westeurope", "AzureStorage"},
+			filters:  Filters{Region: []string{"westeurope"}, Service: []string{"AzureStorage"}},
 			expected: []Prefix{{Address: "2603:1020:206::/48", Region: "westeurope", Service: "AzureStorage"}},
 		},
 		{
 			name:     "filter case-insensitive",
 			ipType:   "ipv4",
-			filter:   []string{"WESTEUROPE", "azurestorage"},
+			filters:  Filters{Region: []string{"WESTEUROPE"}, Service: []string{"azurestorage"}},
 			expected: []Prefix{{Address: "20.50.32.0/19", Region: "westeurope", Service: "AzureStorage"}},
 		},
 		{
 			name:     "no matches",
 			ipType:   "ipv4",
-			filter:   []string{"southpole", "*"},
+			filters:  Filters{Region: []string{"southpole"}},
 			expected: nil,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := filtrateIPRanges(raw, tc.ipType, tc.filter)
+			got, err := filtrateIPRanges(raw, tc.ipType, tc.filters)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, got)
 		})
@@ -115,21 +115,32 @@ func TestFiltrateIPRanges(t *testing.T) {
 }
 
 func TestFiltrateIPRangesInvalidJSON(t *testing.T) {
-	_, err := filtrateIPRanges("not json", "ipv4", []string{"*", "*"})
+	_, err := filtrateIPRanges("not json", "ipv4", Filters{})
 	assert.Error(t, err)
 }
 
 func TestFiltrateIPRangesValidation(t *testing.T) {
 	t.Run("empty payload", func(t *testing.T) {
-		_, err := filtrateIPRanges(`{}`, "ipv4", []string{"*", "*"})
+		_, err := filtrateIPRanges(`{}`, "ipv4", Filters{})
 		assert.ErrorContains(t, err, "no IP ranges found")
 	})
 
 	t.Run("invalid CIDR", func(t *testing.T) {
 		raw := `{"values":[{"name":"BadService","properties":{"addressPrefixes":["not-a-cidr"]}}]}`
-		_, err := filtrateIPRanges(raw, "ipv4", []string{"*", "*"})
+		_, err := filtrateIPRanges(raw, "ipv4", Filters{})
 		assert.ErrorContains(t, err, `service "BadService" prefix 1`)
 	})
+}
+
+func TestFiltrateIPRangesMultipleValues(t *testing.T) {
+	raw := loadFixture(t)
+
+	got, err := filtrateIPRanges(raw, "ipv4", Filters{
+		Region:  []string{"eastus", "WESTEUROPE"},
+		Service: []string{"azurestorage", "MissingService"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []Prefix{{Address: "20.50.32.0/19", Region: "westeurope", Service: "AzureStorage"}}, got)
 }
 
 func TestJSONURLRegex(t *testing.T) {

--- a/internal/github/logic.go
+++ b/internal/github/logic.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/kaumnen/cipr/internal/utils"
 )
@@ -16,11 +15,11 @@ type IPRange struct {
 }
 
 type Config struct {
-	Source        string
-	IPType        string
-	FilterService string
-	List          string
-	Verbosity     string
+	Source         string
+	IPType         string
+	FilterServices []string
+	List           string
+	Verbosity      string
 }
 
 // nonCIDRKeys are top-level keys in the /meta payload whose values are not
@@ -43,7 +42,7 @@ func GetIPRanges(ctx context.Context, config Config) error {
 		return err
 	}
 
-	filtered := filtrate(ranges, config.IPType, config.FilterService)
+	filtered := filtrate(ranges, config.IPType, config.FilterServices)
 	if config.List != "" {
 		return printListedValues(filtered, config.List)
 	}
@@ -85,7 +84,7 @@ func parseMeta(rawData string) ([]IPRange, error) {
 	return ranges, nil
 }
 
-func filtrate(ranges []IPRange, ipType, filterService string) []IPRange {
+func filtrate(ranges []IPRange, ipType string, filterServices []string) []IPRange {
 	var result []IPRange
 	for _, r := range ranges {
 		if ipType == "ipv4" && !utils.IsIPv4(r.CIDR) {
@@ -94,7 +93,7 @@ func filtrate(ranges []IPRange, ipType, filterService string) []IPRange {
 		if ipType == "ipv6" && !utils.IsIPv6(r.CIDR) {
 			continue
 		}
-		if filterService != "" && !strings.EqualFold(r.Service, filterService) {
+		if len(filterServices) > 0 && !utils.ContainsIgnoreCase(filterServices, r.Service) {
 			continue
 		}
 		result = append(result, r)

--- a/internal/github/logic_test.go
+++ b/internal/github/logic_test.go
@@ -94,11 +94,11 @@ func TestFiltrate(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name          string
-		ipType        string
-		filterService string
-		expectedLen   int
-		assertService string
+		name           string
+		ipType         string
+		filterServices []string
+		expectedLen    int
+		assertService  string
 	}{
 		{
 			name:        "ipv4 only, no service filter",
@@ -111,30 +111,30 @@ func TestFiltrate(t *testing.T) {
 			expectedLen: 7,
 		},
 		{
-			name:          "both families, filter actions",
-			ipType:        "",
-			filterService: "actions",
-			expectedLen:   4,
-			assertService: "actions",
+			name:           "both families, filter actions",
+			ipType:         "",
+			filterServices: []string{"actions"},
+			expectedLen:    4,
+			assertService:  "actions",
 		},
 		{
-			name:          "ipv4 + service filter case-insensitive",
-			ipType:        "ipv4",
-			filterService: "ACTIONS",
-			expectedLen:   3,
-			assertService: "actions",
+			name:           "ipv4 + service filter case-insensitive",
+			ipType:         "ipv4",
+			filterServices: []string{"ACTIONS"},
+			expectedLen:    3,
+			assertService:  "actions",
 		},
 		{
-			name:          "nonexistent service yields empty",
-			ipType:        "",
-			filterService: "nonexistent",
-			expectedLen:   0,
+			name:           "nonexistent service yields empty",
+			ipType:         "",
+			filterServices: []string{"nonexistent"},
+			expectedLen:    0,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filtrate(ranges, tc.ipType, tc.filterService)
+			result := filtrate(ranges, tc.ipType, tc.filterServices)
 			assert.Equal(t, tc.expectedLen, len(result))
 			if tc.assertService != "" {
 				for _, r := range result {
@@ -143,6 +143,16 @@ func TestFiltrate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFiltrateMultipleServices(t *testing.T) {
+	ranges := []IPRange{
+		{CIDR: "1.1.1.0/24", Service: "actions"},
+		{CIDR: "2.2.2.0/24", Service: "web"},
+		{CIDR: "3.3.3.0/24", Service: "api"},
+	}
+
+	assert.Equal(t, ranges[:2], filtrate(ranges, "", []string{"ACTIONS", "web"}))
 }
 
 func TestPrintIPRanges(t *testing.T) {


### PR DESCRIPTION
adds comma-separated values to AWS Azure and GitHub individual filters

keeps the AWS and Azure composite filter behavior

uses OR matching within a dimension and AND matching across dimensions

includes provider tests and matching documentation in cipr-docs

checks: `go test -v -cover ./...` `go build ./...` `golangci-lint run`

closes #60