### PR TITLE
feat: support multiple gcp filter values

### DIFF
--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -25,18 +25,13 @@ var gcpCmd = &cobra.Command{
 
 		ipType := resolveIPType(viper.GetBool("gcp_ipv4"), viper.GetBool("gcp_ipv6"))
 		filter := viper.GetString("gcp-filter")
-		filterScope := viper.GetString("gcp-filter-scope")
-		filterService := viper.GetString("gcp-filter-service")
-
-		if filter != "" && (filterScope != "" || filterService != "") {
-			return errors.New("--filter cannot be used with individual filter flags")
+		filters := gcp.Filters{
+			Scope:   viper.GetStringSlice("gcp-filter-scope"),
+			Service: viper.GetStringSlice("gcp-filter-service"),
 		}
 
-		var gcpFilter string
-		if filter != "" {
-			gcpFilter = filter
-		} else {
-			gcpFilter = fmt.Sprintf("%s,%s", filterScope, filterService)
+		if filter != "" && (len(filters.Scope) > 0 || len(filters.Service) > 0) {
+			return errors.New("--filter cannot be used with individual filter flags")
 		}
 
 		source := utils.ResolveSource("gcp")
@@ -47,14 +42,15 @@ var gcpCmd = &cobra.Command{
 			return gcp.GetIPRanges(cmd.Context(), gcp.Config{
 				Source:    source,
 				IPType:    "both",
-				Filter:    gcpFilter,
+				Filter:    filter,
+				Filters:   filters,
 				List:      list,
 				Verbosity: verbosity,
 			})
 		}
 
 		return gcp.GetIPRanges(cmd.Context(), gcp.Config{
-			Source: source, IPType: ipType, Filter: gcpFilter, Verbosity: verbosity,
+			Source: source, IPType: ipType, Filter: filter, Filters: filters, Verbosity: verbosity,
 		})
 	},
 }
@@ -67,8 +63,8 @@ func init() {
 	gcpCmd.Flags().Bool("ipv4", false, "Get only IPv4 ranges")
 	gcpCmd.Flags().Bool("ipv6", false, "Get only IPv6 ranges")
 	gcpCmd.Flags().String("filter", "", "Filter results. Syntax: scope,service")
-	gcpCmd.Flags().String("filter-scope", "", "Filter results by Google Cloud scope (for example, us-central1 or global)")
-	gcpCmd.Flags().String("filter-service", "", "Filter results by Google Cloud service")
+	gcpCmd.Flags().StringSlice("filter-scope", []string{}, "Filter results by Google Cloud scope (comma-separated, for example, us-central1,global)")
+	gcpCmd.Flags().StringSlice("filter-service", []string{}, "Filter results by Google Cloud service (comma-separated)")
 	gcpCmd.Flags().String("list", "", "List unique values for a dimension instead of IP ranges. Valid: scopes, services. Composes with --filter-* flags; ignores --ipv4/--ipv6.")
 
 	viper.BindPFlag("gcp_ipv4", gcpCmd.Flags().Lookup("ipv4"))

--- a/internal/gcp/logic.go
+++ b/internal/gcp/logic.go
@@ -32,8 +32,14 @@ type Config struct {
 	Source    string
 	IPType    string
 	Filter    string
+	Filters   Filters
 	List      string
 	Verbosity string
+}
+
+type Filters struct {
+	Scope   []string
+	Service []string
 }
 
 func GetIPRanges(ctx context.Context, config Config) error {
@@ -46,7 +52,11 @@ func GetIPRanges(ctx context.Context, config Config) error {
 	if config.List != "" {
 		ipType = "both"
 	}
-	prefixes, err := filtrateIPRanges(rawData, ipType, separateFilters(config.Filter))
+	filters := config.Filters
+	if config.Filter != "" {
+		filters = filtersFromComposite(config.Filter)
+	}
+	prefixes, err := filtrateIPRanges(rawData, ipType, filters)
 	if err != nil {
 		return err
 	}
@@ -73,7 +83,22 @@ func separateFilters(filterFlagValues string) []string {
 	return filters[:2]
 }
 
-func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]Prefix, error) {
+func filtersFromComposite(filter string) Filters {
+	parts := separateFilters(filter)
+	return Filters{
+		Scope:   wildcardToEmpty(parts[0]),
+		Service: wildcardToEmpty(parts[1]),
+	}
+}
+
+func wildcardToEmpty(value string) []string {
+	if value == "*" {
+		return nil
+	}
+	return []string{value}
+}
+
+func filtrateIPRanges(rawData, ipType string, filters Filters) ([]Prefix, error) {
 	var data IPsData
 	if err := json.Unmarshal([]byte(rawData), &data); err != nil {
 		return nil, fmt.Errorf("parse gcp cloud ip-ranges json: %w", err)
@@ -105,7 +130,7 @@ func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]Prefix, e
 		if wrongFamily {
 			return nil, fmt.Errorf("validate gcp %s prefix %d: %q has the wrong address family", family, i+1, address)
 		}
-		if !matchesFilter(source, filterSlice) || !ipVersionMatches(address, ipType) {
+		if !matchesFilter(source, filters) || !ipVersionMatches(address, ipType) {
 			continue
 		}
 		result = append(result, Prefix{Address: address, Scope: source.Scope, Service: source.Service})
@@ -113,9 +138,9 @@ func filtrateIPRanges(rawData, ipType string, filterSlice []string) ([]Prefix, e
 	return result, nil
 }
 
-func matchesFilter(prefix sourcePrefix, filterSlice []string) bool {
-	return (filterSlice[0] == "*" || strings.EqualFold(prefix.Scope, filterSlice[0])) &&
-		(filterSlice[1] == "*" || strings.EqualFold(prefix.Service, filterSlice[1]))
+func matchesFilter(prefix sourcePrefix, filters Filters) bool {
+	return (len(filters.Scope) == 0 || utils.ContainsIgnoreCase(filters.Scope, prefix.Scope)) &&
+		(len(filters.Service) == 0 || utils.ContainsIgnoreCase(filters.Service, prefix.Service))
 }
 
 func ipVersionMatches(address, ipType string) bool {

--- a/internal/gcp/logic_test.go
+++ b/internal/gcp/logic_test.go
@@ -124,7 +124,7 @@ func TestFiltrateIPRanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := filtrateIPRanges(rawData, tt.ipType, separateFilters(tt.filter))
+			got, err := filtrateIPRanges(rawData, tt.ipType, filtersFromComposite(tt.filter))
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -149,7 +149,7 @@ func TestFiltrateIPRangesValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := filtrateIPRanges(tt.raw, "both", separateFilters(""))
+			_, err := filtrateIPRanges(tt.raw, "both", Filters{})
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.want)
 		})
@@ -161,7 +161,7 @@ func TestFiltrateIPRangesValidatesExcludedEntries(t *testing.T) {
 		{"ipv4Prefix":"192.0.2.0/24","service":"Google Cloud","scope":"global"},
 		{"ipv6Prefix":"invalid","service":"Google Cloud","scope":"elsewhere"}
 	]}`
-	_, err := filtrateIPRanges(rawData, "ipv4", separateFilters("global,"))
+	_, err := filtrateIPRanges(rawData, "ipv4", filtersFromComposite("global,"))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "validate gcp IPv6 prefix 2")
 }
@@ -171,10 +171,28 @@ func TestFiltrateIPRangesFiltersService(t *testing.T) {
 		{"ipv4Prefix":"192.0.2.0/24","service":"Google Cloud","scope":"global"},
 		{"ipv4Prefix":"198.51.100.0/24","service":"Future Service","scope":"global"}
 	]}`
-	got, err := filtrateIPRanges(rawData, "ipv4", separateFilters(",google cloud"))
+	got, err := filtrateIPRanges(rawData, "ipv4", filtersFromComposite(",google cloud"))
 	require.NoError(t, err)
 	assert.Equal(t, []Prefix{
 		{Address: "192.0.2.0/24", Scope: "global", Service: "Google Cloud"},
+	}, got)
+}
+
+func TestFiltrateIPRangesMultipleValues(t *testing.T) {
+	rawData := `{"prefixes":[
+		{"ipv4Prefix":"192.0.2.0/24","service":"Google Cloud","scope":"global"},
+		{"ipv4Prefix":"198.51.100.0/24","service":"Future Service","scope":"asia-east1"},
+		{"ipv4Prefix":"203.0.113.0/24","service":"Other Service","scope":"africa-south1"}
+	]}`
+
+	got, err := filtrateIPRanges(rawData, "ipv4", Filters{
+		Scope:   []string{"GLOBAL", "asia-east1"},
+		Service: []string{"google cloud", "FUTURE SERVICE"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []Prefix{
+		{Address: "192.0.2.0/24", Scope: "global", Service: "Google Cloud"},
+		{Address: "198.51.100.0/24", Scope: "asia-east1", Service: "Future Service"},
 	}, got)
 }
 


### PR DESCRIPTION
adds comma-separated values to Google Cloud scope and service filters

uses OR matching within a dimension and AND matching across dimensions

keeps the composite `--filter` behavior

updates the GCP documentation on cipr-docs main

checks: `go test -v -cover ./...` `go build ./...` `golangci-lint run`
